### PR TITLE
Support multiple instances of the same energy term

### DIFF
--- a/src/bagel/energies.py
+++ b/src/bagel/energies.py
@@ -50,7 +50,6 @@ class EnergyTerm(ABC):
         oracle: Oracle,
         inheritable: bool,
         weight: float = 1.0,
-        custom_name: str | None = None,
     ) -> None:
         """
         Initialises EnergyTerm class.
@@ -69,10 +68,8 @@ class EnergyTerm(ABC):
             Whether the energy term is inheritable.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
         """
-        self.name = name if custom_name is None else f'{name}_{custom_name}'
+        self.name = name
         self.oracle = oracle
         self.weight = weight
         self.inheritable = inheritable
@@ -196,7 +193,7 @@ class PTMEnergy(EnergyTerm):
         self,
         oracle: FoldingOracle,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises Predicted Template Modelling Score Energy class.
@@ -207,10 +204,14 @@ class PTMEnergy(EnergyTerm):
             The oracle to use for the energy term.
         weight: float
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        super().__init__(name='pTM', inheritable=True, oracle=oracle, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'pTM'
+        else:
+            name = f'pTM_{name}'
+        super().__init__(name=name, inheritable=True, oracle=oracle, weight=weight)
         assert isinstance(self.oracle, FoldingOracle), 'Oracle must be an instance of FoldingOracle'
         assert 'ptm' in self.oracle.result_class.model_fields, 'PTMEnergy requires oracle to return ptm in result_class'
 
@@ -242,7 +243,7 @@ class ChemicalPotentialEnergy(EnergyTerm):
         target_size: int = 0,
         chemical_potential: float = 1.0,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises Chemical Potential Energy class.
@@ -259,10 +260,14 @@ class ChemicalPotentialEnergy(EnergyTerm):
             The chemical potential of the system.
         weight: float
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        super().__init__(name='chem_pot', inheritable=True, oracle=oracle, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'chem_pot'
+        else:
+            name = f'chem_pot_{name}'
+        super().__init__(name=name, inheritable=True, oracle=oracle, weight=weight)
         self.power = power
         self.target_size = target_size
         self.chemical_potential = chemical_potential
@@ -295,7 +300,7 @@ class PLDDTEnergy(EnergyTerm):
         residues: list[Residue] | None,
         inheritable: bool = True,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """Initialises Local Predicted Local Distance Difference Test Energy class.
 
@@ -310,16 +315,22 @@ class PLDDTEnergy(EnergyTerm):
             residue could then be added to this energy term.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
         if isinstance(self, OverallPLDDTEnergy):
-            name = 'global_pLDDT'
+            base_name = 'global_pLDDT'
         elif isinstance(self, PLDDTEnergy):
-            name = 'local_pLDDT'
+            base_name = 'local_pLDDT'
         else:
             raise ValueError(f'Unknown energy term type: {type(self)}')
-        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight, custom_name=custom_name)
+
+        if name is None:
+            name = base_name
+        else:
+            name = f'{base_name}_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight)
         if residues is not None:
             self.residue_groups = [residue_list_to_group(residues)]
         else:
@@ -349,7 +360,7 @@ class OverallPLDDTEnergy(PLDDTEnergy):
     Overall Predicted Local Distance Difference Test energy.
     """
 
-    def __init__(self, oracle: FoldingOracle, weight: float = 1.0, custom_name: str | None = None) -> None:
+    def __init__(self, oracle: FoldingOracle, weight: float = 1.0, name: str | None = None) -> None:
         """Initialises Overall Predicted Local Distance Difference Test Energy class.
 
         Parameters
@@ -358,10 +369,10 @@ class OverallPLDDTEnergy(PLDDTEnergy):
             The oracle to use for the energy term.
         weight: float
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        super().__init__(oracle=oracle, inheritable=True, weight=weight, residues=None, custom_name=custom_name)
+        super().__init__(oracle=oracle, inheritable=True, weight=weight, residues=None, name=name)
         assert isinstance(self.oracle, FoldingOracle), 'Oracle must be an instance of FoldingOracle'
         assert 'local_plddt' in self.oracle.result_class.model_fields, (
             'OverallPLDDTEnergy requires oracle to return local_plddt in result_class'
@@ -383,7 +394,7 @@ class SurfaceAreaEnergy(EnergyTerm):
         probe_radius: float | None = None,
         max_sasa: float | None = None,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises Surface Area Energy Class.
@@ -401,11 +412,19 @@ class SurfaceAreaEnergy(EnergyTerm):
             The VdW-radius of the solvent molecules used in the SASA calculation. Default is the water VdW-radius.
         max_sasa: float or None, default=None
             The maximum SASA value used if normalization is enabled. Default is the full surface area of a Sulfur atom.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = 'surface_area' if residues is None else f'{"selective_" if residues is not None else ""}surface_area'
-        super().__init__(name=name, inheritable=inheritable, oracle=oracle, weight=weight, custom_name=custom_name)
+        base_name = (
+            'surface_area' if residues is None else f'{"selective_" if residues is not None else ""}surface_area'
+        )
+
+        if name is None:
+            name = base_name
+        else:
+            name = f'{base_name}_{name}'
+
+        super().__init__(name=name, inheritable=inheritable, oracle=oracle, weight=weight)
         self.residue_groups = [residue_list_to_group(residues)] if residues is not None else []
         self.probe_radius = probe_radius_water if probe_radius is None else probe_radius
         self.max_sasa = max_sasa_values['S'] if max_sasa is None else max_sasa
@@ -439,7 +458,7 @@ class HydrophobicEnergy(EnergyTerm):
         residues: list[Residue] | None = None,
         surface_only: bool = False,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises hydrophobic energy class.
@@ -458,12 +477,15 @@ class HydrophobicEnergy(EnergyTerm):
             in the calculation. If true, result is scaled by normalised solute accessible surface area values.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        super().__init__(
-            name='hydrophobic', inheritable=inheritable, oracle=oracle, weight=weight, custom_name=custom_name
-        )
+        if name is None:
+            name = 'hydrophobic'
+        else:
+            name = f'hydrophobic_{name}'
+
+        super().__init__(name=name, inheritable=inheritable, oracle=oracle, weight=weight)
         self.residue_groups = [residue_list_to_group(residues)] if residues is not None else []
         self.surface_only = surface_only
         assert isinstance(self.oracle, FoldingOracle), 'Oracle must be an instance of FoldingOracle'
@@ -501,7 +523,7 @@ class PAEEnergy(EnergyTerm):
         inheritable: bool = True,
         cross_term_only: bool = True,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises the alignment error energy class.
@@ -520,11 +542,17 @@ class PAEEnergy(EnergyTerm):
             also considers the uncertainty in distances between atoms within the same group.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = f'{"cross_" if cross_term_only else ""}PAE'
-        super().__init__(name=name, inheritable=inheritable, oracle=oracle, weight=weight, custom_name=custom_name)
+        base_name = f'{"cross_" if cross_term_only else ""}PAE'
+
+        if name is None:
+            name = base_name
+        else:
+            name = f'{base_name}_{name}'
+
+        super().__init__(name=name, inheritable=inheritable, oracle=oracle, weight=weight)
         self.cross_term_only = cross_term_only
         if len(residues) == 1:
             self.residue_groups = [residue_list_to_group(residues[0]), residue_list_to_group(residues[0])]
@@ -572,7 +600,7 @@ class RingSymmetryEnergy(EnergyTerm):
         inheritable: bool = True,
         direct_neighbours_only: bool = False,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """Initialises ring symmetry energy class.
 
@@ -591,11 +619,17 @@ class RingSymmetryEnergy(EnergyTerm):
             only), or each group to all other groups. Defaults to the latter.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = f'{"neighbour_" if direct_neighbours_only else ""}ring_symmetry'
-        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight, custom_name=custom_name)
+        base_name = f'{"neighbour_" if direct_neighbours_only else ""}ring_symmetry'
+
+        if name is None:
+            name = base_name
+        else:
+            name = f'{base_name}_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight)
         assert (len(symmetry_groups) > 1) and (len(symmetry_groups[0]) >= 1), 'Multiple symmetry groups required.'
         self.residue_groups = [residue_list_to_group(symmetry_group) for symmetry_group in symmetry_groups]
         self.direct_neighbours_only: bool = direct_neighbours_only
@@ -638,7 +672,7 @@ class SeparationEnergy(EnergyTerm):
         residues: tuple[list[Residue], list[Residue]],
         inheritable: bool = True,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises separation energy class.
@@ -654,11 +688,15 @@ class SeparationEnergy(EnergyTerm):
             residue could then be added to this energy term.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = 'separation'
-        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'separation'
+        else:
+            name = f'separation_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight)
         self.residue_groups = [residue_list_to_group(residues[0]), residue_list_to_group(residues[1])]
         assert isinstance(self.oracle, FoldingOracle), 'Oracle must be an instance of FoldingOracle'
         assert 'structure' in self.oracle.result_class.model_fields, (
@@ -695,7 +733,7 @@ class GlobularEnergy(EnergyTerm):
         residues: list[Residue] | None = None,
         inheritable: bool = True,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises globular energy class.
@@ -711,11 +749,15 @@ class GlobularEnergy(EnergyTerm):
             residue could then be added to this energy term.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = 'globular'
-        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'globular'
+        else:
+            name = f'globular_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight)
         self.residue_groups = [residue_list_to_group(residues)] if residues is not None else []
         assert isinstance(self.oracle, FoldingOracle), 'Oracle must be an instance of FoldingOracle'
         assert 'structure' in self.oracle.result_class.model_fields, (
@@ -752,7 +794,7 @@ class TemplateMatchEnergy(EnergyTerm):
         backbone_only: bool = False,
         distogram_separation: bool = False,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises template match energy class.
@@ -773,11 +815,17 @@ class TemplateMatchEnergy(EnergyTerm):
             instead.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = f'{"backbone_" if backbone_only else ""}template_match'
-        super().__init__(name=name, oracle=oracle, inheritable=False, weight=weight, custom_name=custom_name)
+        base_name = f'{"backbone_" if backbone_only else ""}template_match'
+
+        if name is None:
+            name = base_name
+        else:
+            name = f'{base_name}_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=False, weight=weight)
         self.residue_groups = [residue_list_to_group(residues)]
         self.template_atoms = template_atoms
         self.backbone_only = backbone_only
@@ -828,7 +876,7 @@ class SecondaryStructureEnergy(EnergyTerm):
         target_secondary_structure: str,
         inheritable: bool = True,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises the secondary structure energy class.
@@ -846,11 +894,17 @@ class SecondaryStructureEnergy(EnergyTerm):
             residue could then be added to this energy term.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = f'{target_secondary_structure.lower()}'
-        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight, custom_name=custom_name)
+        base_name = f'{target_secondary_structure.lower()}'
+
+        if name is None:
+            name = base_name
+        else:
+            name = f'{base_name}_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=inheritable, weight=weight)
         self.residue_groups = [residue_list_to_group(residues)]
         options = ('alpha-helix', 'beta-sheet', 'coil')
         assert target_secondary_structure in options, f'{target_secondary_structure} not recognised. options: {options}'
@@ -898,7 +952,7 @@ class EllipsoidEnergy(EnergyTerm):
         k_attractive: float = 1.0,
         k_repulsive: float = 10.0,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initializes elipsoid energy class.
@@ -917,11 +971,15 @@ class EllipsoidEnergy(EnergyTerm):
             all backbone atoms within the ellipsoid volume.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = 'ellipsoid'
-        super().__init__(name=name, oracle=oracle, inheritable=True, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'ellipsoid'
+        else:
+            name = f'ellipsoid_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=True, weight=weight)
         self.residue_groups = []
         self.k_attractive = k_attractive
         self.k_repulsive = k_repulsive
@@ -993,7 +1051,7 @@ class CuboidEnergy(EnergyTerm):
         k_repulsive: float = 10.0,
         sharpness: float = 2.0,
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initializes cuboid energy class.
@@ -1015,11 +1073,15 @@ class CuboidEnergy(EnergyTerm):
             perfect right angled vertex.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = 'cuboid'
-        super().__init__(name=name, oracle=oracle, inheritable=True, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'cuboid'
+        else:
+            name = f'cuboid_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=True, weight=weight)
         self.residue_groups = []
         self.k_attractive = k_attractive
         self.k_repulsive = k_repulsive
@@ -1080,7 +1142,7 @@ class EmbeddingsSimilarityEnergy(EnergyTerm):
         residues: list[Residue],
         reference_embeddings: npt.NDArray[np.float64],
         weight: float = 1.0,
-        custom_name: str | None = None,
+        name: str | None = None,
     ) -> None:
         """
         Initialises EmbeddingsSimilarityEnergy class.
@@ -1095,11 +1157,15 @@ class EmbeddingsSimilarityEnergy(EnergyTerm):
             The reference embeddings to compare to.
         weight: float = 1.0
             The weight of the energy term.
-        custom_name: str | None = None
-            Optional custom name to append to the energy term name.
+        name: str | None = None
+            Optional name to append to the energy term name.
         """
-        name = 'embeddings_similarity'
-        super().__init__(name=name, oracle=oracle, inheritable=False, weight=weight, custom_name=custom_name)
+        if name is None:
+            name = 'embeddings_similarity'
+        else:
+            name = f'embeddings_similarity_{name}'
+
+        super().__init__(name=name, oracle=oracle, inheritable=False, weight=weight)
         # with the current implementation, the energy term is not inheritable, as reference embeddings would change
         # and would need to be changed dynamically, which is not fully supported yet
         self.residue_groups = [residue_list_to_group(residues)]

--- a/src/bagel/state.py
+++ b/src/bagel/state.py
@@ -80,7 +80,7 @@ class State:
         # Check that all energy term names are unique
         energy_term_names = [term.name for term in self.energy_terms]
         assert len(energy_term_names) == len(set(energy_term_names)), (
-            f"Energy term names must be unique. Found duplicates: {energy_term_names}. Please rename using 'custom_name'."
+            f"Energy term names must be unique. Found duplicates: {energy_term_names}. Please rename using 'name'."
         )
 
         total_energy = 0.0


### PR DESCRIPTION
Added custom_name parameter to EnergyTerm class to allow user to append to energy term names.

Added assertion to get_energy() to ensure that energy term names are unique

2 formatting changes in esm2.py and esmfold.py were made by pre-commit checks.

All pre-commit checks and full pytest --oracles local passed.

Related to #58 

