### PR TITLE
Fix for template rmsd error

### DIFF
--- a/src/bagel/energies.py
+++ b/src/bagel/energies.py
@@ -17,6 +17,7 @@ import pandas as pd
 from .oracles import Oracle, OracleResult, OraclesResultDict
 from .oracles.folding import FoldingResult, FoldingOracle
 from .oracles.embedding import EmbeddingResult, EmbeddingOracle
+from .oracles.folding.utils import reorder_atoms_in_template
 
 
 # first row is chain_ids and second row is corresponding residue indices.
@@ -838,7 +839,7 @@ class TemplateMatchEnergy(EnergyTerm):
     def compute(self, oracles_result: OraclesResultDict) -> tuple[float, float]:
         structure = oracles_result.get_structure(self.oracle)
         structure_atoms = structure[self.get_atom_mask(structure, residue_group_index=0)]
-        template_atoms = self.template_atoms
+        template_atoms = reorder_atoms_in_template(self.template_atoms)
         if self.backbone_only:
             structure_atoms = structure_atoms[np.isin(structure_atoms.atom_name, backbone_atoms)]
             template_atoms = template_atoms[np.isin(template_atoms.atom_name, backbone_atoms)]

--- a/src/bagel/oracles/folding/utils.py
+++ b/src/bagel/oracles/folding/utils.py
@@ -3,8 +3,10 @@ from typing import Union, List
 from io import StringIO
 from biotite.structure import AtomArray
 from biotite.structure.io.pdb import PDBFile
+from bagel.constants import atom_order
 
 import pandas as pd  # This is necessary because its "unique" method does not sort elements and leaves them as they are
+import numpy as np
 
 
 def pdb_file_to_atomarray(pdb_path: Union[str, StringIO]) -> AtomArray:
@@ -44,3 +46,32 @@ def reindex_chains(atomarray: AtomArray, custom_chain_idx: List[str]) -> AtomArr
         new_id = id_conversion[current_id]
         atoms.chain_id[i] = new_id
     return atoms
+
+
+### Reordering atoms to match ESMFold output ###
+def get_unique_residues(atom_array: AtomArray):
+    residues = []
+    for i in range(len(atom_array)):
+        res_key = (atom_array.res_id[i], atom_array.chain_id[i])
+        if res_key not in residues:
+            residues.append(res_key)
+    return residues
+
+
+def reorder_atoms_in_template(atom_array: AtomArray) -> AtomArray:
+    residues = get_unique_residues(atom_array)
+
+    reordered_indices = []
+    for res_id, chain_id in residues:
+        # get atom indices for this residue
+        indices = np.where((atom_array.res_id == res_id) & (atom_array.chain_id == chain_id))[0]
+        atoms = atom_array[indices]
+
+        # sort using atom_order
+        sort_keys = [atom_order.get(name, float('inf')) for name in atoms.atom_name]
+        sorted_indices = indices[np.argsort(sort_keys)]
+
+        reordered_indices.extend(sorted_indices)
+
+    # Return a reordered AtomArray
+    return atom_array[reordered_indices]

--- a/tests/integration_tests/test_grandcanonical.py
+++ b/tests/integration_tests/test_grandcanonical.py
@@ -9,7 +9,9 @@ def add_chemical_potential_energy(state):
         if hasattr(term, 'oracle'):
             folding_oracle = term.oracle
             break
-    if folding_oracle is not None and not any(isinstance(term, bg.energies.ChemicalPotentialEnergy) for term in state.energy_terms):
+    if folding_oracle is not None and not any(
+        isinstance(term, bg.energies.ChemicalPotentialEnergy) for term in state.energy_terms
+    ):
         state.energy_terms.append(
             bg.energies.ChemicalPotentialEnergy(
                 oracle=folding_oracle, target_size=3, chemical_potential=1.0, weight=1.0

--- a/tests/unit_tests/test_energies.py
+++ b/tests/unit_tests/test_energies.py
@@ -395,6 +395,7 @@ def test_RingSymmetryEnergy(
 
 # --- ChemicalPotentialEnergy ---
 
+
 def test_ChemicalPotentialEnergy(
     fake_esmfold: bg.oracles.folding.ESMFold,
     square_structure_residues: list[bg.Residue],
@@ -434,8 +435,8 @@ def test_ChemicalPotentialEnergy_with_embedding_oracle(
     )
     unweighted_energy, weighted_energy = energy.compute(oracles_result=oracles_result)
     # Should be: 1.5 * (abs(3-5))**2 = 1.5 * 4 = 6.0
-    assert np.isclose(unweighted_energy, 6.0), f"unweighted energy is incorrect: {unweighted_energy}"
-    assert np.isclose(weighted_energy, 12.0), f"weighted energy is incorrect: {weighted_energy}"
+    assert np.isclose(unweighted_energy, 6.0), f'unweighted energy is incorrect: {unweighted_energy}'
+    assert np.isclose(weighted_energy, 12.0), f'weighted energy is incorrect: {weighted_energy}'
 
 
 def test_RingSymmetryEnergy_with_direct_neighbours_only(

--- a/tests/unit_tests/test_oracles.py
+++ b/tests/unit_tests/test_oracles.py
@@ -2,13 +2,17 @@ import pytest
 from bagel.oracles.base import OraclesResultDict, Oracle, OracleResult
 from bagel.chain import Chain, Residue
 
+
 class DummyOracle(Oracle):
     result_class = OracleResult
+
     def predict(self, chains):
         pass
 
+
 class DummyResult(OracleResult):
     input_chains: list[Chain]
+
     def save_attributes(self, filepath):
         pass
 

--- a/tests/unit_tests/test_reorder_atoms.py
+++ b/tests/unit_tests/test_reorder_atoms.py
@@ -1,0 +1,33 @@
+import pytest
+from biotite.structure import AtomArray
+from biotite.structure.io import load_structure
+from bagel.constants import atom_order
+from bagel.oracles.folding.utils import reorder_atoms_in_template, get_unique_residues
+
+
+def test_reorder_atoms_in_template(pdb_path):
+    # Load the structure from the PDB file
+    structure = load_structure(pdb_path)
+
+    # Check original order is not correct for at least one residue
+    out_of_order = False
+    for res_id, chain_id in get_unique_residues(structure):
+        res_mask = (structure.res_id == res_id) & (structure.chain_id == chain_id)
+        atom_names = structure.atom_name[res_mask]
+        indices = [atom_order.get(atom, float('inf')) for atom in atom_names]
+        if indices != sorted(indices):
+            out_of_order = True
+            break
+
+    assert out_of_order, 'Original structure is already ordered by atom_order; test cannot fail as expected.'
+
+    # Now reorder and check all residues are in correct order
+    reordered = reorder_atoms_in_template(structure)
+    for res_id, chain_id in get_unique_residues(reordered):
+        res_mask = (reordered.res_id == res_id) & (reordered.chain_id == chain_id)
+        atom_names = reordered.atom_name[res_mask]
+        indices = [atom_order.get(atom, float('inf')) for atom in atom_names]
+        assert indices == sorted(indices), (
+            f'Residue ({chain_id}, {res_id}) atoms {list(atom_names)} '
+            f'not correctly reordered by reorder_atoms_in_template'
+        )


### PR DESCRIPTION
Fixes #77 

Added a reordering function (`reorder_atoms_in_template`) and utilised it in `TemplateMatchEnergy`, along with an unit test to check that reordering works as expected. 




