### PR TITLE
chore: upgrade boileroom and add automatic XDG cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/_build
 # Project specific
 data
 logs_step_*
+.model_cache

--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ To use Modal, one needs to create an account and authenticate through:
 
         modal token new
 
-You also need to set `HF_MODEL_DIR` to an accessible folder, where HuggingFace models will be stored.
+You also need to set `MODEL_DIR` to an accessible folder, where deep learning models will be stored (i.e. cached).
+
+Note on cache location and persistence:
+- By default, examples may resolve `MODEL_DIR` to an XDG-compliant cache directory such as `~/.cache/bagel/models` (or the path in `$XDG_CACHE_HOME`). This directory is user-writable and persists across runs.
+- The cache is not automatically cleaned by the application. If you wish to reclaim disk space, remove models manually (e.g., `rm -rf ~/.cache/bagel/models`) or configure your own housekeeping policy. Advanced users on Linux can use `systemd-tmpfiles` rules per their environment.
 
 ### Google Colab
 A prototyping, but unscalable alterantive is to run BAGEL in Google Colab, having an access to a T4 processing unit for free. See this [notebook](https://colab.research.google.com/drive/1dtX8j6t5VhSed4iiqSrjM35DyPSFE1yF?usp=sharing), which includes the installation, and the template script for [simple binder](scripts/binders/simple_binder.py).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},
@@ -15,7 +15,7 @@ keywords = ["protein", "protein design", "optimization", "monte carlo", "samplin
 requires-python = ">=3.11"
 dependencies = [
     "biotite>=1.0.1",
-    "boileroom==0.1.3",
+    "boileroom==0.2.1",
     "numpy>=2.2.0",
     "pandas>=2.2.3",
     "pydantic>=2.10.6",

--- a/scripts/technical-report/binders/ca4.py
+++ b/scripts/technical-report/binders/ca4.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/binders/derf7.py
+++ b/scripts/technical-report/binders/derf7.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/binders/egfr.py
+++ b/scripts/technical-report/binders/egfr.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/disordered/asyn.py
+++ b/scripts/technical-report/disordered/asyn.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/disordered/cd28.py
+++ b/scripts/technical-report/disordered/cd28.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/disordered/p53.py
+++ b/scripts/technical-report/disordered/p53.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/disordered/sumo1.py
+++ b/scripts/technical-report/disordered/sumo1.py
@@ -8,8 +8,6 @@ import pathlib as pl
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
-
 def main(
     use_modal: bool = False,
     binder_sequence: str = None,

--- a/scripts/technical-report/mimic_oxidoreductase.py
+++ b/scripts/technical-report/mimic_oxidoreductase.py
@@ -11,7 +11,6 @@ import modal
 def run_generate_mimic() -> Any:
 
     # Get the value of an environment variable
-    os.environ["HF_MODEL_DIR"] = os.path.expanduser("~/hugging_face/")
     use_modal = False
 
     # Check

--- a/src/bagel/__init__.py
+++ b/src/bagel/__init__.py
@@ -6,7 +6,8 @@ Protein design library used to find the amino acid sequences that give rise to s
 criteria.
 """
 
-from .utils import get_version_from_pyproject
+from .utils import get_version_from_pyproject, resolve_and_set_model_dir
+resolve_and_set_model_dir()
 
 __version__ = get_version_from_pyproject()
 
@@ -14,5 +15,6 @@ from .chain import Chain, Residue
 from .state import State
 from .system import System
 from . import constants, energies, minimizer, mutation, oracles
+
 
 __all__ = ['Chain', 'Residue', 'State', 'System', 'constants', 'energies', 'minimizer', 'mutation', 'oracles']

--- a/src/bagel/oracles/embedding/esm2.py
+++ b/src/bagel/oracles/embedding/esm2.py
@@ -10,8 +10,8 @@ from ...chain import Chain
 from .base import EmbeddingResult, EmbeddingOracle
 from typing import List, Any
 from boileroom import app  # type: ignore
-from boileroom.esm2 import ESM2Output  # type: ignore
-from boileroom.esm2 import ESM2 as ESM2Boiler
+from boileroom.models.esm.esm2 import ESM2Output  # type: ignore
+from boileroom.models.esm.esm2 import ESM2 as ESM2Boiler
 from modal import App
 import logging
 
@@ -93,7 +93,7 @@ class ESM2(EmbeddingOracle):
             return self._post_process(self._remote_embed(processed_chains))
         else:
             logger.debug('Given that use_modal is False, trying to embed with ESM-2 locally...')
-            assert os.environ.get('HF_MODEL_DIR'), 'HF_MODEL_DIR must be set when using ESM-2 locally'
+            assert os.environ.get('MODEL_DIR'), 'MODEL_DIR must be set when using ESM-2 locally'
             return self._post_process(self._local_embed(processed_chains))
 
     def _remote_embed(self, sequence: List[str]) -> ESM2Output:

--- a/src/bagel/oracles/folding/esmfold.py
+++ b/src/bagel/oracles/folding/esmfold.py
@@ -13,8 +13,8 @@ from pydantic import field_validator
 from .base import FoldingOracle, FoldingResult
 from typing import List, Any, Type
 from boileroom import app  # type: ignore
-from boileroom.esmfold import ESMFoldOutput  # type: ignore
-from boileroom.esmfold import ESMFold as ESMFoldBoiler
+from boileroom.models.esm.esmfold import ESMFoldOutput  # type: ignore
+from boileroom.models.esm.esmfold import ESMFold as ESMFoldBoiler
 from modal import App
 
 from biotite.structure import AtomArray
@@ -139,7 +139,7 @@ class ESMFold(FoldingOracle):
             return self._reduce_output(self._remote_fold(self._pre_process(chains)), chains)
         else:
             logger.debug('Given that use_modal is False, trying to fold with ESMFold locally...')
-            assert os.environ.get('HF_MODEL_DIR'), 'HF_MODEL_DIR must be set when using ESMFold locally'
+            assert os.environ.get('MODEL_DIR'), 'MODEL_DIR must be set when using ESMFold locally'
             return self._reduce_output(self._local_fold(self._pre_process(chains)), chains)
 
     def _remote_fold(self, sequence: List[str]) -> ESMFoldOutput:

--- a/src/bagel/utils.py
+++ b/src/bagel/utils.py
@@ -1,6 +1,8 @@
 import re
 import pathlib
 import os
+import tempfile
+import logging
 import numpy as np
 from typing import Optional
 
@@ -9,6 +11,8 @@ from biotite.structure import AtomArray
 from .constants import aa_dict
 
 aa_dict_3to1 = {v: k for k, v in aa_dict.items()}
+
+logger = logging.getLogger(__name__)
 
 
 def get_version_from_pyproject(pyproject_path: Optional[str] = None) -> Optional[str]:
@@ -103,16 +107,27 @@ def resolve_and_set_model_dir() -> pathlib.Path:
     pathlib.Path
         Absolute path to the resolved model directory.
     """
-    if os.environ.get("MODEL_DIR"):
-        resolved = pathlib.Path(os.environ["MODEL_DIR"]).expanduser().resolve()
-    else:
-        xdg_cache_home = os.getenv("XDG_CACHE_HOME")
-        if xdg_cache_home:
-            base_cache_dir = pathlib.Path(xdg_cache_home).expanduser().resolve()
+    try:
+        if os.environ.get("MODEL_DIR"):
+            resolved = pathlib.Path(os.environ["MODEL_DIR"]).expanduser().resolve()
         else:
-            base_cache_dir = pathlib.Path.home() / ".cache"
-        resolved = (base_cache_dir / "bagel" / "models").resolve()
+            xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+            if xdg_cache_home:
+                base_cache_dir = pathlib.Path(xdg_cache_home).expanduser().resolve()
+            else:
+                base_cache_dir = pathlib.Path.home() / ".cache"
+            resolved = (base_cache_dir / "bagel" / "models").resolve()
 
-    resolved.mkdir(parents=True, exist_ok=True)
-    os.environ["MODEL_DIR"] = str(resolved)
-    return resolved
+        resolved.mkdir(parents=True, exist_ok=True)
+        os.environ["MODEL_DIR"] = str(resolved)
+        return resolved
+    except (OSError, PermissionError) as exc:
+        logger.warning(f"Falling back to a temporary model cache due to filesystem error: {str(exc)}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"Falling back to a temporary model cache due to unexpected error: {str(exc)}")
+
+    # Fallback to a user-writable temporary directory; ensure directory exists
+    fallback_base = pathlib.Path(tempfile.gettempdir()) / "bagel" / "models"
+    fallback_base.mkdir(parents=True, exist_ok=True)
+    os.environ["MODEL_DIR"] = str(fallback_base)
+    return fallback_base

--- a/src/bagel/utils.py
+++ b/src/bagel/utils.py
@@ -1,6 +1,6 @@
 import re
 import pathlib
-import copy
+import os
 import numpy as np
 from typing import Optional
 
@@ -86,3 +86,33 @@ def sequence_from_atomarray(atoms: AtomArray) -> str:
     protein_atoms = atoms[protein_mask]
     ca_mask = protein_atoms.atom_name == 'CA'
     return ''.join([aa_dict_3to1[res_name] for res_name in protein_atoms[ca_mask].res_name])
+
+
+def resolve_and_set_model_dir() -> pathlib.Path:
+    """
+    Resolve and set the MODEL_DIR environment variable to a user-writable cache
+    location following XDG conventions.
+
+    Precedence:
+    1) Respect existing MODEL_DIR if set.
+    2) Use XDG_CACHE_HOME if defined; otherwise default to ~/.cache.
+    3) Append "bagel/models" and create the directory if it does not exist.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to the resolved model directory.
+    """
+    if os.environ.get("MODEL_DIR"):
+        resolved = pathlib.Path(os.environ["MODEL_DIR"]).expanduser().resolve()
+    else:
+        xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+        if xdg_cache_home:
+            base_cache_dir = pathlib.Path(xdg_cache_home).expanduser().resolve()
+        else:
+            base_cache_dir = pathlib.Path.home() / ".cache"
+        resolved = (base_cache_dir / "bagel" / "models").resolve()
+
+    resolved.mkdir(parents=True, exist_ok=True)
+    os.environ["MODEL_DIR"] = str(resolved)
+    return resolved

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import pytest
 import shutil
 import numpy as np
 import pathlib as pl
-from unittest.mock import Mock
 from biotite.structure import AtomArray, Atom, array, concatenate
 from biotite.structure.io import load_structure
 import bagel as bg
@@ -32,8 +31,8 @@ to bugs. The below fixture for example would create a new ESMFolder for each mod
 This was leading to test breaking exceptions.
 """
 
-from boileroom import app
 import modal
+from boileroom import app
 
 
 @pytest.fixture(scope='session')
@@ -47,7 +46,6 @@ def modal_app_context(request) -> modal.App:
     else:
         yield None
 
-
 @pytest.fixture(scope='session')  # ensures only 1 Modal App is requested per process
 def esmfold(request, modal_app_context) -> bg.oracles.folding.ESMFold:
     """
@@ -58,7 +56,6 @@ def esmfold(request, modal_app_context) -> bg.oracles.folding.ESMFold:
     if flag == 'skip':
         pytest.skip(reason='--oracles flag of the origional pytest call set to skip')
     elif flag == 'local':
-        os.environ.setdefault('HF_MODEL_DIR', os.path.expanduser('~/hugging_face/'))
         model = bg.oracles.folding.ESMFold(use_modal=False)
         yield model
         del model
@@ -78,7 +75,6 @@ def esm2(request, modal_app_context) -> bg.oracles.embedding.ESM2:
     if flag == 'skip':
         pytest.skip(reason='--oracles flag of the origional pytest call set to skip')
     elif flag == 'local':
-        os.environ.setdefault('HF_MODEL_DIR', os.path.expanduser('~/hugging_face/'))
         model = bg.oracles.embedding.ESM2(use_modal=False)
         yield model
         del model

--- a/uv.lock
+++ b/uv.lock
@@ -166,7 +166,7 @@ wheels = [
 
 [[package]]
 name = "biobagel"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },
@@ -198,7 +198,7 @@ local = [
 [package.metadata]
 requires-dist = [
     { name = "biotite", specifier = ">=1.0.1" },
-    { name = "boileroom", specifier = "==0.1.3" },
+    { name = "boileroom", specifier = "==0.2.1" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.1" },
@@ -272,7 +272,7 @@ wheels = [
 
 [[package]]
 name = "boileroom"
-version = "0.1.3"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "biotite" },
@@ -281,9 +281,9 @@ dependencies = [
     { name = "numpy" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/32/e2ebb42cf849a2571cc16188c425e90ef7aa97b11696aaa32d5ac541683c/boileroom-0.1.3.tar.gz", hash = "sha256:2cd4f739ba00822d0fa160e5ad6a65b9fc617f80fe8c0e3aeb0211496747d7bf", size = 300620, upload_time = "2025-08-04T19:09:05.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c3/f864a3d9833be7c1127ef49852f9aba4e16e3217af109eccf432cf4c58ff/boileroom-0.2.1.tar.gz", hash = "sha256:065b81a019765cd79124b41e27e349019b96e2ada01b34c90c6c106be37b6247", size = 307471, upload_time = "2025-09-24T09:01:30.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/60/3ae3607bd7c5da83ae6720100c8aab108c60674f95b97cd28858275e3d4d/boileroom-0.1.3-py3-none-any.whl", hash = "sha256:47721068e7f04524437d59e0c8dfd5f37aef6219da3de48a70c44e03ecd39cc4", size = 21394, upload_time = "2025-08-04T19:09:04.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e2/f8441d7443a3baefba9da20e95dc0241a5c8b5bbf4cfbeb4436c7cb81af1/boileroom-0.2.1-py3-none-any.whl", hash = "sha256:2da7e708d5146d359aff57898bf3e6f26b6b8c908fab2d3847dd970c9c7af224", size = 22340, upload_time = "2025-09-24T09:01:29.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic model cache setup using MODEL_DIR with XDG-compliant defaults and safe fallbacks; project initializes MODEL_DIR on import.

- Documentation
  - Replaced HF_MODEL_DIR with MODEL_DIR guidance; added notes on cache location, persistence, manual cleanup, and advanced cleanup options.

- Chores
  - Added .model_cache to ignore rules.
  - Bumped version to 0.1.7 and updated dependency boileroom to 0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->