### PR TITLE
Check template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},

--- a/src/bagel/__init__.py
+++ b/src/bagel/__init__.py
@@ -7,6 +7,7 @@ criteria.
 """
 
 from .utils import get_version_from_pyproject, resolve_and_set_model_dir
+
 resolve_and_set_model_dir()
 
 __version__ = get_version_from_pyproject()

--- a/src/bagel/energies.py
+++ b/src/bagel/energies.py
@@ -706,9 +706,9 @@ class LISEnergy(EnergyTerm):
             if self.intensive:
                 value = -np.mean(lis_scores)  # Negative because you want to be interpreted as an energy
             else:
-                # 0.5 is to avoid double-counting of LIS pairs, which you would if PAE(ij) is asymmetric due 
+                # 0.5 is to avoid double-counting of LIS pairs, which you would if PAE(ij) is asymmetric due
                 # to masking above
-                value = - 0.5 * np.sum(lis_scores)  # Negative because you want to be interpreted as an energy
+                value = -0.5 * np.sum(lis_scores)  # Negative because you want to be interpreted as an energy
 
         return value, value * self.weight
 
@@ -943,7 +943,7 @@ class FlexEvoBindEnergy(EnergyTerm):
 
             # Get the chain_ids and res_ids for the residues in the first group
             chain_ids, res_ids = self.residue_groups[main]
-            
+
             min_distances = []  # List to store the minimum distances for each residue in the main group
 
             # Now iterate over each residue in the first group
@@ -951,7 +951,7 @@ class FlexEvoBindEnergy(EnergyTerm):
                 # Extract from the structure the atoms corresponding to the residues with current chain_id and res_id
                 curr_residue_mask = (structure.chain_id == chain_id) & (structure.res_id == res_id)
 
-                # Get the atoms corresponding to the current residue            
+                # Get the atoms corresponding to the current residue
                 curr_residue_atoms = structure[curr_residue_mask]
                 if len(curr_residue_atoms) == 0:
                     continue
@@ -959,7 +959,7 @@ class FlexEvoBindEnergy(EnergyTerm):
                 diff = partner_atoms.coord[np.newaxis, :, :] - curr_residue_atoms.coord[:, np.newaxis, :]
                 dist_mat = np.linalg.norm(diff, axis=2)
                 min_dist = float(np.min(dist_mat))
-                min_distances.append(min_dist) # Store the minimum distance for this residue
+                min_distances.append(min_dist)  # Store the minimum distance for this residue
 
             # Calculate the average of these minimum distances
             if len(min_distances) == 0:
@@ -967,7 +967,7 @@ class FlexEvoBindEnergy(EnergyTerm):
                 continue
             average_min_distance = float(np.mean(min_distances))
             value = average_min_distance
-            
+
             # If plddt_weighted is True, divide by the average pLDDT of the residues in the group
             # In this case, this energy term is the EvoBind loss function mentioned above, but symmetrized.
             # in the sense that what is the binder and what is the hotspot does not matter.
@@ -983,7 +983,7 @@ class FlexEvoBindEnergy(EnergyTerm):
                 if mask_count > 0:
                     average_plddt = float(np.mean(plddt[main_mask]))
                     denom = average_plddt if average_plddt > 0.0 else np.finfo(float).eps
-                    value /= denom      
+                    value /= denom
 
             # Scale value by the number of residues in the group, so that eventually you can
             # calculate a weighted average between residues in the binder and hotspot
@@ -997,7 +997,7 @@ class FlexEvoBindEnergy(EnergyTerm):
         # calculate the (weighted) average over saved values
         total_count = sum(counts_list)
         value = float(np.sum(values_list) / total_count) if total_count > 0 else 0.0
-            
+
         return value, value * self.weight
 
 
@@ -1125,7 +1125,9 @@ class TemplateMatchEnergy(EnergyTerm):
             structure_atoms = structure_atoms[np.isin(structure_atoms.atom_name, backbone_atoms)]
             template_atoms = template_atoms[np.isin(template_atoms.atom_name, backbone_atoms)]
         try:
-            assert len(structure_atoms) == len(template_atoms), 'Different number of atoms in template and given residues'
+            assert len(structure_atoms) == len(template_atoms), (
+                'Different number of atoms in template and given residues'
+            )
         except AssertionError:
             print(f'Number of atoms in template: {len(template_atoms)}')
             print(f'Number of atoms in structure: {len(structure_atoms)}')

--- a/src/bagel/utils.py
+++ b/src/bagel/utils.py
@@ -95,8 +95,7 @@ def sequence_from_atomarray(atoms: AtomArray) -> str:
     return ''.join([aa_dict_3to1[res_name] for res_name in protein_atoms[ca_mask].res_name])
 
 
-
-def get_sequence_from_fasta( pdb_id : str, sequence_index: int = 0 ) -> str:
+def get_sequence_from_fasta(pdb_id: str, sequence_index: int = 0) -> str:
     """Download sequence from the FASTA file using the pdb ID. This sequence is
     complete unlike that extracted from the PDB AtomArray object that only contains
     residues for which coordinates have been determined.
@@ -107,7 +106,7 @@ def get_sequence_from_fasta( pdb_id : str, sequence_index: int = 0 ) -> str:
     sequence : str, sequence of the protein
     """
     # 1) Download the FASTA file from the RCSB for a given PDB ID
-    fasta_file_path = rcsb.fetch(pdb_id, format="fasta", target_path=None, overwrite=True)
+    fasta_file_path = rcsb.fetch(pdb_id, format='fasta', target_path=None, overwrite=True)
     # 2) Read the FASTA file into a Biotite FastaFile object
     fasta_file = fasta.FastaFile.read(fasta_file_path)
 
@@ -116,10 +115,13 @@ def get_sequence_from_fasta( pdb_id : str, sequence_index: int = 0 ) -> str:
     for seq_obj in sequences.values():
         output_sequences.append(str(seq_obj))
 
-    assert sequence_index < len(output_sequences), f"Requested sequence index {sequence_index} but only {len(output_sequences)} sequences found."
+    assert sequence_index < len(output_sequences), (
+        f'Requested sequence index {sequence_index} but only {len(output_sequences)} sequences found.'
+    )
 
     return output_sequences[sequence_index]
-  
+
+
 def resolve_and_set_model_dir() -> pathlib.Path:
     """
     Resolve and set the MODEL_DIR environment variable to a user-writable cache
@@ -136,33 +138,34 @@ def resolve_and_set_model_dir() -> pathlib.Path:
         Absolute path to the resolved model directory.
     """
     try:
-        if os.environ.get("MODEL_DIR"):
-            resolved = pathlib.Path(os.environ["MODEL_DIR"]).expanduser().resolve()
+        if os.environ.get('MODEL_DIR'):
+            resolved = pathlib.Path(os.environ['MODEL_DIR']).expanduser().resolve()
         else:
-            xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+            xdg_cache_home = os.getenv('XDG_CACHE_HOME')
             if xdg_cache_home:
                 base_cache_dir = pathlib.Path(xdg_cache_home).expanduser().resolve()
             else:
-                base_cache_dir = pathlib.Path.home() / ".cache"
-            resolved = (base_cache_dir / "bagel" / "models").resolve()
+                base_cache_dir = pathlib.Path.home() / '.cache'
+            resolved = (base_cache_dir / 'bagel' / 'models').resolve()
 
         resolved.mkdir(parents=True, exist_ok=True)
-        os.environ["MODEL_DIR"] = str(resolved)
+        os.environ['MODEL_DIR'] = str(resolved)
         return resolved
     except (OSError, PermissionError) as exc:
-        logger.warning(f"Falling back to a temporary model cache due to filesystem error: {str(exc)}")
+        logger.warning(f'Falling back to a temporary model cache due to filesystem error: {str(exc)}')
     except Exception as exc:  # noqa: BLE001
-        logger.warning(f"Falling back to a temporary model cache due to unexpected error: {str(exc)}")
+        logger.warning(f'Falling back to a temporary model cache due to unexpected error: {str(exc)}')
 
     # Fallback to a user-writable temporary directory; ensure directory exists
-    fallback_base = pathlib.Path(tempfile.gettempdir()) / "bagel" / "models"
+    fallback_base = pathlib.Path(tempfile.gettempdir()) / 'bagel' / 'models'
     fallback_base.mkdir(parents=True, exist_ok=True)
-    os.environ["MODEL_DIR"] = str(fallback_base)
+    os.environ['MODEL_DIR'] = str(fallback_base)
     return fallback_base
 
-def get_reconciled_sequence( atoms: AtomArray, fasta_sequence: str) -> None:
+
+def get_reconciled_sequence(atoms: AtomArray, fasta_sequence: str) -> None:
     """
-    Take a sequence from an AtomArray object. If there are missing residues in the AtomArray, 
+    Take a sequence from an AtomArray object. If there are missing residues in the AtomArray,
     use the provided fasta_sequence to fill in the gaps.
     Note that if the AtomArray and FASTA sequence have mismatches, AtomArray sequence is preferred
     but a warning is raised.
@@ -172,7 +175,7 @@ def get_reconciled_sequence( atoms: AtomArray, fasta_sequence: str) -> None:
     atoms: AtomArray
         AtomArray containing all atoms.
     faata_sequence: str | None
-        Amino acid sequence in 1-letter convention. If None, no reconciliation is performed 
+        Amino acid sequence in 1-letter convention. If None, no reconciliation is performed
         and a random residue is chosen for missing residues.
 
     Returns
@@ -184,7 +187,7 @@ def get_reconciled_sequence( atoms: AtomArray, fasta_sequence: str) -> None:
 
     Raises
     ------
-    Warning 
+    Warning
         If there is a mismatch between the sequence derived from `atoms` and the provided `sequence`.
     """
     offset = 1  # Because residue IDs in PDB files start from 1
@@ -201,7 +204,7 @@ def get_reconciled_sequence( atoms: AtomArray, fasta_sequence: str) -> None:
     added = False
 
     for res_id in range(1, max_res_id + 1):
-        try: 
+        try:
             aa_pdb = atoms.res_name[atoms.res_id == res_id][0]
             aa_pdb = aa_dict_3to1[aa_pdb]
             reconciled_sequence.append(aa_pdb)
@@ -222,7 +225,9 @@ def get_reconciled_sequence( atoms: AtomArray, fasta_sequence: str) -> None:
                 # This is because the FASTA sequence can be shorter than the PDB sequence because of discrepancies
                 aa_seq = fasta_sequence[res_id - offset]
                 if aa_pdb != aa_seq:
-                    print( f'Non-critical WARNING: Mismatch between PDB and sequence at residue {res_id}: PDB = {aa_pdb} vs FASTA = {aa_seq}')
+                    print(
+                        f'Non-critical WARNING: Mismatch between PDB and sequence at residue {res_id}: PDB = {aa_pdb} vs FASTA = {aa_seq}'
+                    )
             except IndexError:
                 pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def modal_app_context(request) -> modal.App:
     else:
         yield None
 
+
 @pytest.fixture(scope='session')  # ensures only 1 Modal App is requested per process
 def esmfold(request, modal_app_context) -> bg.oracles.folding.ESMFold:
     """

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -43,6 +43,7 @@ def test_get_atomarray_in_residue_range(pdb_path):
     assert np.array_equal(unique_residue_ids, expected_residue_ids)
     assert np.array_equal(unique_residue_names, expected_residue_names)
 
+
 import numpy as np
 from biotite.structure import AtomArray, array, Atom
 from bagel.utils import get_reconciled_sequence
@@ -55,7 +56,7 @@ aa_dict_1to3 = {v: k for k, v in aa_dict.items()}
 def create_fake_atomarray(res_ids, res_names, chain_id='A'):
     """
     Create a fake AtomArray for testing.
-    
+
     Parameters
     ----------
     res_ids : list of int
@@ -64,7 +65,7 @@ def create_fake_atomarray(res_ids, res_names, chain_id='A'):
         Residue names in 3-letter code (e.g., 'ALA', 'GLY')
     chain_id : str
         Chain identifier
-        
+
     Returns
     -------
     AtomArray
@@ -72,7 +73,7 @@ def create_fake_atomarray(res_ids, res_names, chain_id='A'):
     """
     # Create a list of Atom objects
     atoms_list = []
-    
+
     for res_id, res_name in zip(res_ids, res_names):
         # Add a CA atom for each residue (minimum needed)
         atoms_list.append(
@@ -82,85 +83,85 @@ def create_fake_atomarray(res_ids, res_names, chain_id='A'):
                 res_name=res_name,
                 chain_id=chain_id,
                 atom_name='CA',
-                element='C'
+                element='C',
             )
         )
-    
+
     # Create AtomArray from list of Atom objects
     return array(atoms_list)
 
 
 def test_get_reconciled_sequence():
     """Test the get_reconciled_sequence function with various scenarios."""
-    
-    print("Testing get_reconciled_sequence...")
-    
+
+    print('Testing get_reconciled_sequence...')
+
     # Test 1: Perfect match - no missing residues, sequences match
-    print("\nTest 1: Perfect match")
+    print('\nTest 1: Perfect match')
     res_ids = [1, 2, 3, 4, 5]
     res_names = ['ALA', 'GLY', 'MET', 'PHE', 'TRP']
     atoms = create_fake_atomarray(res_ids, res_names)
     fasta_seq = 'AGMFW'  # ALA, GLY, MET, PHE, TRP
     result, added = get_reconciled_sequence(atoms, fasta_seq)
     assert result == 'AGMFW', f"Expected 'AGMFW', got '{result}'"
-    assert added == False, "No residues should be added"
-    print("✓ Test 1 passed")
-    
+    assert added == False, 'No residues should be added'
+    print('✓ Test 1 passed')
+
     # Test 2: Missing residues in AtomArray - should use FASTA to fill gaps
-    print("\nTest 2: Missing residues (gaps in AtomArray)")
+    print('\nTest 2: Missing residues (gaps in AtomArray)')
     res_ids = [1, 2, 4, 5]  # Missing residue 3
     res_names = ['ALA', 'GLY', 'PHE', 'TRP']
     atoms = create_fake_atomarray(res_ids, res_names)
     fasta_seq = 'AGMFW'  # Full sequence
     result, added = get_reconciled_sequence(atoms, fasta_seq)
     assert result == 'AGMFW', f"Expected 'AGMFW', got '{result}'"
-    assert added == True, "Residues should be added"
-    print("✓ Test 2 passed")
-    
+    assert added == True, 'Residues should be added'
+    print('✓ Test 2 passed')
+
     # Test 3: Mismatch between PDB and FASTA - PDB should be preferred
-    print("\nTest 3: Mismatch between PDB and FASTA")
+    print('\nTest 3: Mismatch between PDB and FASTA')
     res_ids = [1, 2, 3]
     res_names = ['ALA', 'GLY', 'MET']  # PDB has MET
     atoms = create_fake_atomarray(res_ids, res_names)
     fasta_seq = 'AGP'  # FASTA has PRO instead of MET
     result, added = get_reconciled_sequence(atoms, fasta_seq)
     assert result == 'AGM', f"Expected 'AGM' (PDB preferred), got '{result}'"
-    assert added == False, "No residues should be added"
-    print("✓ Test 3 passed (warning expected)")
-    
+    assert added == False, 'No residues should be added'
+    print('✓ Test 3 passed (warning expected)')
+
     # Test 4: Multiple missing residues
-    print("\nTest 4: Multiple missing residues")
+    print('\nTest 4: Multiple missing residues')
     res_ids = [1, 3, 5]  # Missing 2 and 4
     res_names = ['ALA', 'MET', 'TRP']
     atoms = create_fake_atomarray(res_ids, res_names)
     fasta_seq = 'AGMFW'
     result, added = get_reconciled_sequence(atoms, fasta_seq)
     assert result == 'AGMFW', f"Expected 'AGMFW', got '{result}'"
-    assert added == True, "Residues should be added"
-    print("✓ Test 4 passed")
-    
+    assert added == True, 'Residues should be added'
+    print('✓ Test 4 passed')
+
     # Test 5: Missing residues in the middle and at the end
-    print("\nTest 5: Missing residues in the middle and at the end")
+    print('\nTest 5: Missing residues in the middle and at the end')
     res_ids = [1, 2, 5]  # Missing 3 and 4, but has 5 so max_res_id is 5
     res_names = ['ALA', 'GLY', 'TRP']
     atoms = create_fake_atomarray(res_ids, res_names)
     fasta_seq = 'AGMFW'  # Full sequence
     result, added = get_reconciled_sequence(atoms, fasta_seq)
     assert result == 'AGMFW', f"Expected 'AGMFW', got '{result}'"
-    assert added == True, "Residues should be added"
-    print("✓ Test 5 passed")
-    
+    assert added == True, 'Residues should be added'
+    print('✓ Test 5 passed')
+
     # Test 6: No FASTA sequence provided - should use random for missing residues
-    print("\nTest 6: No FASTA sequence (random fill)")
+    print('\nTest 6: No FASTA sequence (random fill)')
     res_ids = [1, 3, 5]
     res_names = ['ALA', 'MET', 'TRP']
     atoms = create_fake_atomarray(res_ids, res_names)
     result, added = get_reconciled_sequence(atoms, None)
-    assert len(result) == 5, f"Expected length 5, got {len(result)}"
-    assert result[0] == 'A', "First residue should be A"
-    assert result[2] == 'M', "Third residue should be M"
-    assert result[4] == 'W', "Fifth residue should be W"
-    assert added == True, "Residues should be added"
-    print("✓ Test 6 passed")
-    
-    print("\n✅ All tests passed!")
+    assert len(result) == 5, f'Expected length 5, got {len(result)}'
+    assert result[0] == 'A', 'First residue should be A'
+    assert result[2] == 'M', 'Third residue should be M'
+    assert result[4] == 'W', 'Fifth residue should be W'
+    assert added == True, 'Residues should be added'
+    print('✓ Test 6 passed')
+
+    print('\n✅ All tests passed!')


### PR DESCRIPTION
- Added functionality to pull sequence from fasta and not the pdb atomarray
- Added assertion and debugging info in EnergyTemplate term


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime error reporting for mismatched template vs. structure atom counts with detailed counts and atom info for easier debugging.

* **New Features**
  * Add ability to fetch FASTA sequences by PDB ID and reconcile structure sequences with FASTA (fill gaps and flag additions).

* **Tests**
  * Add unit tests and helpers covering sequence reconciliation scenarios and a new test fixture for folding/oracle provisioning.

* **Chores**
  * Project version bumped; minor formatting/documentation cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->