### PR TITLE
feat: add HydrogenBondEnergy energy term (#120)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.1.13"
+version = "0.1.14"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},

--- a/src/bagel/energies.py
+++ b/src/bagel/energies.py
@@ -14,6 +14,7 @@ import numpy.typing as npt
 import pandas as pd
 from typing import Literal, Callable, Any
 from biotite.structure import AtomArray, sasa, annotate_sse, superimpose
+from biotite.structure.hbond import hbond
 from .constants import (
     hydrophobic_residues,
     max_sasa_values,
@@ -1525,3 +1526,112 @@ class EmbeddingsSimilarityEnergy(EnergyTerm):
             global_index_list.append(chain_res_to_global[(str(chain_id), int(res_id))])
 
         return global_index_list
+
+
+class HydrogenBondEnergy(EnergyTerm):
+    """
+    Energy term based on the count of hydrogen bonds in the structure.
+    Uses the Baker-Hubbard algorithm to detect hydrogen bonds.
+    The energy is proportional to the negative number of hydrogen bonds,
+    encouraging the formation of hydrogen bonds.
+    """
+
+    def __init__(
+        self,
+        oracle: FoldingOracle,
+        inheritable: bool = True,
+        residues: list[Residue] | None = None,
+        cutoff_dist: float = 2.5,
+        cutoff_angle: float = 120,
+        weight: float = 1.0,
+        name: str | None = None,
+    ) -> None:
+        """
+        Initialises Hydrogen Bond Energy class.
+
+        Parameters
+        ----------
+        oracle: FoldingOracle
+            The oracle to use for the energy term.
+        inheritable: bool, default=True
+            If a new residue is added next to a residue included in this energy term, this dictates whether that new
+            residue could then be added to this energy term.
+        residues: list[Residue] or None, default=None
+            Which residues to include in the calculation. If None, considers all residues by default.
+        cutoff_dist: float, default=2.5
+            The maximal distance (in Angstroms) between the hydrogen and acceptor to be
+            considered a hydrogen bond.
+        cutoff_angle: float, default=120
+            The angle cutoff (in degrees) between Donor-H..Acceptor to be
+            considered a hydrogen bond.
+        weight: float = 1.0
+            The weight of the energy term.
+        name: str | None = None
+            Optional name to append to the energy term name.
+        """
+        if name is None:
+            name = 'hbond'
+        else:
+            name = f'hbond_{name}'
+
+        super().__init__(name=name, inheritable=inheritable, oracle=oracle, weight=weight)
+        self.residue_groups = [residue_list_to_group(residues)] if residues is not None else []
+        self.cutoff_dist = cutoff_dist
+        self.cutoff_angle = cutoff_angle
+        assert isinstance(self.oracle, FoldingOracle), 'Oracle must be an instance of FoldingOracle'
+        assert 'structure' in self.oracle.result_class.model_fields, (
+            'HydrogenBondEnergy requires oracle to return structure in result_class'
+        )
+
+    def compute(self, oracles_result: OraclesResultDict) -> tuple[float, float]:
+        structure = oracles_result.get_structure(self.oracle)
+
+        # Handle empty structure
+        if len(structure) == 0:
+            return 0.0, 0.0
+
+        # If residue groups are specified, create masks for those residues
+        if len(self.residue_groups) > 0:
+            # Get the atom mask for the selected residues
+            selection_mask: npt.NDArray[np.bool_] = self.get_atom_mask(structure, residue_group_index=0)
+
+            # Detect hydrogen bonds within the entire structure
+            triplets = hbond(
+                structure,
+                cutoff_dist=self.cutoff_dist,
+                cutoff_angle=self.cutoff_angle,
+            )
+
+            # Count hydrogen bonds where at least one atom (donor or acceptor) is in the selection
+            if len(triplets) > 0:
+                donor_indices = triplets[:, 0]
+                acceptor_indices = triplets[:, 2]
+                # Count H-bonds where either donor or acceptor is in the selected residues
+                hbond_count = np.sum(selection_mask[donor_indices] | selection_mask[acceptor_indices])
+            else:
+                hbond_count = 0
+
+            # Count number of unique residues in the selected group for normalization
+            selected_structure = structure[selection_mask]
+            n_residues = len(
+                np.unique(np.stack([selected_structure.chain_id, selected_structure.res_id], axis=1), axis=0)
+            )  # Count unique (chain_id, res_id) pairs for multi-chain structures
+        else:
+            # If no residue groups specified, count all hydrogen bonds in the structure
+            triplets = hbond(
+                structure,
+                cutoff_dist=self.cutoff_dist,
+                cutoff_angle=self.cutoff_angle,
+            )
+            hbond_count = len(triplets)
+
+            # Count all residues in the structure for normalization
+            n_residues = len(
+                np.unique(np.stack([structure.chain_id, structure.res_id], axis=1), axis=0)
+            )  # Count unique (chain_id, res_id) pairs for multi-chain structures
+
+        # Negative energy to encourage hydrogen bond formation
+        # Normalize by number of residues to get energy per residue
+        value = -hbond_count / max(n_residues, 1)
+
+        return value, value * self.weight

--- a/tests/unit_tests/test_energies.py
+++ b/tests/unit_tests/test_energies.py
@@ -1193,3 +1193,221 @@ def test_HydropathyEnergy_empty_structure_returns_zero(
 
     assert unweighted_energy == 0.0, 'unweighted energy should be 0 for empty structure'
     assert weighted_energy == 0.0, 'weighted energy should be 0 for empty structure'
+
+
+def test_HydrogenBondEnergy_instantiation(fake_esmfold: bg.oracles.folding.ESMFold) -> None:
+    """Test that HydrogenBondEnergy can be instantiated with default parameters."""
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold)
+    assert energy.name == 'hbond', 'Expected default name for HydrogenBondEnergy'
+    assert energy.weight == 1.0, 'Expected default weight for HydrogenBondEnergy'
+    assert energy.inheritable is True, 'Expected inheritable to be True for HydrogenBondEnergy'
+    assert energy.cutoff_dist == 2.5, 'Expected default cutoff distance for HydrogenBondEnergy'
+    assert energy.cutoff_angle == 120, 'Expected default cutoff angle for HydrogenBondEnergy'
+
+
+def test_HydrogenBondEnergy_with_residues(
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    residues: list[bg.Residue],
+) -> None:
+    """Test that HydrogenBondEnergy can be instantiated with specific residues."""
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold, residues=residues)
+    assert len(energy.residue_groups) == 1, 'Expected one group of residues in HydrogenBondEnergy'
+    chain_ids, res_ids = energy.residue_groups[0]
+    assert np.array_equal(chain_ids, np.array(['A'] * 5 + ['B'])), 'Expected chain IDs to match input residues'
+    assert np.array_equal(res_ids, np.array(list(range(5)) + [0])), 'Expected residue IDs to match input residues'
+
+
+def test_HydrogenBondEnergy_with_custom_parameters(fake_esmfold: bg.oracles.folding.ESMFold) -> None:
+    """Test that HydrogenBondEnergy accepts custom cutoff parameters."""
+    energy = bg.energies.HydrogenBondEnergy(
+        oracle=fake_esmfold,
+        cutoff_dist=3.0,
+        cutoff_angle=130,
+        weight=2.0,
+        name='custom',
+    )
+    assert energy.cutoff_dist == 3.0, 'Expected custom cutoff distance for HydrogenBondEnergy'
+    assert energy.cutoff_angle == 130, 'Expected custom cutoff angle for HydrogenBondEnergy'
+    assert energy.weight == 2.0, 'Expected custom weight for HydrogenBondEnergy'
+    assert energy.name == 'hbond_custom', 'Expected custom name for HydrogenBondEnergy'
+
+
+def test_HydrogenBondEnergy_no_hbonds_in_structure(
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    small_structure: AtomArray,
+) -> None:
+    """Test HydrogenBondEnergy with a structure that has no hydrogen atoms (thus no hydrogen bonds)."""
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = small_structure
+
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold, weight=1.0)
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # No hydrogen atoms = no hydrogen bonds, so energy should be 0
+    assert unweighted_energy == 0.0, 'unweighted energy should be 0 when no hydrogen bonds are present'
+    assert weighted_energy == 0.0, 'weighted energy should be 0 when no hydrogen bonds are present'
+
+
+def test_HydrogenBondEnergy_empty_structure(
+    fake_esmfold: bg.oracles.folding.ESMFold,
+) -> None:
+    """Test HydrogenBondEnergy with an empty structure."""
+    from biotite.structure import AtomArray
+
+    empty_structure = AtomArray(0)
+
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = empty_structure
+
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold, weight=1.0)
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # Empty structure = 0 residues, 0 hydrogen bonds, avoid division by zero
+    assert unweighted_energy == 0.0, 'unweighted energy should be 0 for empty structure'
+    assert weighted_energy == 0.0, 'weighted energy should be 0 for empty structure'
+
+
+def test_HydrogenBondEnergy_weight_applied(
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    small_structure: AtomArray,
+) -> None:
+    """Test that the weight is correctly applied to the energy."""
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = small_structure
+
+    weight = 3.0
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold, weight=weight)
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # Weighted energy should be unweighted energy * weight
+    assert weighted_energy == unweighted_energy * weight, 'Weighted energy should be unweighted energy * weight'
+
+
+def test_HydrogenBondEnergy_residue_selection(
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    small_structure: AtomArray,
+    small_structure_residues: list[bg.Residue],
+) -> None:
+    """Test that HydrogenBondEnergy respects residue selection."""
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = small_structure
+
+    energy = bg.energies.HydrogenBondEnergy(
+        oracle=fake_esmfold,
+        residues=small_structure_residues[:2],
+    )
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # Should compute without error
+    assert isinstance(unweighted_energy, (float, np.floating)), 'unweighted energy should be a float'
+    assert isinstance(weighted_energy, (float, np.floating)), 'weighted energy should be a float'
+
+
+@patch('bagel.energies.hbond')
+def test_HydrogenBondEnergy_energy_values(
+    mock_hbond: Mock,
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    small_structure: AtomArray,
+) -> None:
+    """Test that HydrogenBondEnergy computes correct energy values."""
+    # Mock hbond to return 4 hydrogen bonds in the small_structure (3 residues)
+    # triplets are (donor_idx, hydrogen_idx, acceptor_idx)
+    mock_hbond.return_value = np.array(
+        [
+            [0, 1, 2],
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 0],
+        ]
+    )
+
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = small_structure
+
+    weight = 2.0
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold, weight=weight)
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # Expected: small_structure has 3 unique residues
+    # hbond_count = 4 (from mock)
+    # n_residues = 3
+    # value = -4 / 3 ≈ -1.333...
+    expected_value = -4.0 / 3.0
+
+    assert np.isfinite(unweighted_energy), 'energy should be finite'
+    assert np.isclose(unweighted_energy, expected_value), 'unweighted energy is incorrect'
+    assert np.isclose(weighted_energy, expected_value * weight), 'weighted energy is incorrect'
+
+
+@patch('bagel.energies.hbond')
+def test_HydrogenBondEnergy_energy_values_with_residue_selection(
+    mock_hbond: Mock,
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    small_structure: AtomArray,
+    small_structure_residues: list[bg.Residue],
+) -> None:
+    """Test that HydrogenBondEnergy normalizes by selected residue count."""
+    # Mock hbond to return 2 hydrogen bonds
+    # Both involve atoms from the selected residues (first 2)
+    mock_hbond.return_value = np.array(
+        [
+            [0, 1, 2],
+            [2, 3, 4],
+        ]
+    )
+
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = small_structure
+
+    weight = 1.5
+    energy = bg.energies.HydrogenBondEnergy(
+        oracle=fake_esmfold,
+        residues=small_structure_residues[:2],  # Select first 2 residues
+        weight=weight,
+    )
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # Expected: only 2 residues selected
+    # Both hbonds involve atoms in those 2 residues: hbond_count = 2
+    # n_residues = 2 (selected count, not total)
+    # value = -2 / 2 = -1.0
+    expected_value = -2.0 / 2.0
+
+    assert np.isfinite(unweighted_energy), 'energy should be finite'
+    assert np.isclose(unweighted_energy, expected_value), 'unweighted energy is incorrect'
+    assert np.isclose(weighted_energy, expected_value * weight), 'weighted energy is incorrect'
+
+
+@patch('bagel.energies.hbond')
+def test_HydrogenBondEnergy_zero_hbonds(
+    mock_hbond: Mock,
+    fake_esmfold: bg.oracles.folding.ESMFold,
+    small_structure: AtomArray,
+) -> None:
+    """Test HydrogenBondEnergy returns zero when no hydrogen bonds are found."""
+    # Mock hbond to return empty array (no hydrogen bonds)
+    mock_hbond.return_value = np.empty((0, 3), dtype=int)
+
+    mock_folding_result = Mock(bg.oracles.folding.ESMFoldResult)
+    mock_folding_result.structure = small_structure
+
+    weight = 2.0
+    energy = bg.energies.HydrogenBondEnergy(oracle=fake_esmfold, weight=weight)
+    oracles_result = OraclesResultDict({fake_esmfold: mock_folding_result})
+    unweighted_energy, weighted_energy = energy.compute(oracles_result)
+
+    # Expected: 0 hydrogen bonds
+    # hbond_count = 0
+    # n_residues = 3
+    # value = -0 / 3 = 0.0
+    expected_value = 0.0
+
+    assert np.isfinite(unweighted_energy), 'energy should be finite'
+    assert np.isclose(unweighted_energy, expected_value), 'unweighted energy is incorrect'
+    assert np.isclose(weighted_energy, expected_value * weight), 'weighted energy is incorrect'


### PR DESCRIPTION
* feat: add HydrogenBondEnergy energy term with Baker-Hubbard detection

Add a new energy term that counts hydrogen bonds in protein structures using the Baker-Hubbard algorithm. The energy is proportional to the negative number of hydrogen bonds, encouraging their formation during optimization.

Key changes:
- Implement HydrogenBondEnergy class in energies.py with configurable parameters:
  * cutoff_dist: hydrogen-acceptor distance threshold (default 2.5 Å)
  * cutoff_angle: donor-hydrogen-acceptor angle threshold (default 120°)
- Integrate biotite.structure.hbond for hydrogen bond detection
- Support both global and selective residue-based energy calculation
- Count hydrogen bonds where donor OR acceptor is in selected residues
- Normalize by unique residue count for proper energy scaling

The energy function is: value = -hbond_count / max(n_residues, 1) This negative normalization encourages hydrogen bond formation as part of the protein design objective function.

Ref: Baker-Hubbard algorithm implementation in biotite
     https://www.biotite-python.org/latest/apidoc/biotite.structure.hbond.html

Testing:
tests/unit_tests/test_energies.py: Add 10 comprehensive unit tests:
- Test default parameter initialization (name, weight, cutoff values)
- Test with selected residue subgroups
- Test with custom cutoff parameters
- Test edge cases (empty structure, no H atoms, no H-bonds)
- Test weight application to energy values
- Test residue selection masking
- Test expected energy values with mocked H-bond data:
  * Verify -4/3 ≈ -1.333 with 4 bonds, 3 residues
  * Verify -2/2 = -1.0 with selective residues
  * Verify 0.0 with zero H-bonds

All 10 tests pass with expected value assertions matching computed values.

Code Quality:
- PEP 8 compliant with proper docstring formatting
- Type hints for all parameters and return values
- Proper handling of empty structures and edge cases

Bump version 0.1.13 → 0.1.14

Files modified:
- pyproject.toml: Update version to 0.1.14
- src/bagel/energies.py: Add HydrogenBondEnergy class implementation
- tests/unit_tests/test_energies.py: Add 10 unit tests for HydrogenBondEnergy

Refs: Issue #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hydrogen-bond energy term for structural energy calculations, with configurable distance and angle cutoff parameters.
* **Tests**
  * Added comprehensive unit tests for hydrogen-bond energy functionality.
* **Chores**
  * Bumped project version to 0.1.14.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softnanolab/bagel/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->