### PR TITLE
feat: add BAGEL-CAR scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.1.13"
+version = "0.1.14"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},

--- a/scripts/car/README.md
+++ b/scripts/car/README.md
@@ -1,0 +1,44 @@
+# BAGEL-CAR Recipes
+
+These scripts are the manuscript-facing BAGEL-CAR recipe translations for the
+two BAGEL design stages:
+
+- `bgl_sol_cd20_dimer.py`: the CD20-dimer objective used for `BGL` and as the
+  source backbone objective for `SOL`.
+- `lnk_cd20_monomer.py`: the CD20-monomer seed objective used before the
+  `LNK` RFdiffusion linker-fusion stage.
+
+The labels follow the manuscript (`BGL`, `SOL`, `LNK-AA`, `LNK-AB`, `LNK-BB`,
+`CD20A`, `CD20B`, and `binder`). `LNK` is used only as the umbrella stage label.
+The dimer script uses BAGEL-compatible chain IDs `C20A`, `C20B`, and `BIND`
+because current BAGEL restricts AtomArray chain IDs to fewer than five
+characters.
+
+## Usage
+
+Both scripts default to running ESMFold on Modal:
+
+```bash
+uv run python scripts/car/bgl_sol_cd20_dimer.py --help
+uv run python scripts/car/lnk_cd20_monomer.py --help
+```
+
+For local execution, set `--use_modal=False` and point `MODEL_DIR` at a
+location with the ESMFold weights (see the project README for details):
+
+```bash
+MODEL_DIR=/path/to/models uv run python scripts/car/lnk_cd20_monomer.py \
+  --use_modal=False
+```
+
+For a minimal smoke run, override the default production-scale tempering
+schedule:
+
+```bash
+uv run python scripts/car/bgl_sol_cd20_dimer.py --use_modal=True \
+  --n_cycles=1 --n_steps_low=1 --n_steps_high=1 --log_frequency=1
+uv run python scripts/car/lnk_cd20_monomer.py --use_modal=True \
+  --n_cycles=1 --n_steps_low=1 --n_steps_high=1 --log_frequency=1
+```
+
+Omit those counter overrides for full recipe runs.

--- a/scripts/car/bgl_sol_cd20_dimer.py
+++ b/scripts/car/bgl_sol_cd20_dimer.py
@@ -54,6 +54,8 @@ def main(
         ('n_mutations', n_mutations),
         ('log_frequency', log_frequency),
     ):
+        if not isinstance(value, int):
+            raise TypeError(f'{name} must be an integer')
         if value < 1:
             raise ValueError(f'{name} must be a positive integer')
 
@@ -74,13 +76,18 @@ def main(
 
     # -- Binder chain (80 residues, fully mutable) --------------------------
     binder_length = 80
+    allowed_residues = set(AMINO_ACIDS_NO_CYSTEINE)
     if binder_sequence is None:
         binder_sequence = ''.join(random.choice(AMINO_ACIDS_NO_CYSTEINE) for _ in range(binder_length))
     else:
         if len(binder_sequence) != binder_length:
-            raise ValueError('Binder sequence must be 80 residues')
-        if 'C' in binder_sequence:
-            raise ValueError('Historical initialization excluded cysteine')
+            raise ValueError(f'binder_sequence must be {binder_length} residues, got {len(binder_sequence)}')
+        invalid = set(binder_sequence) - allowed_residues
+        if invalid:
+            raise ValueError(
+                f'binder_sequence contains invalid residues {sorted(invalid)!r}; '
+                f'allowed (uppercase, cysteine excluded): {sorted(allowed_residues)!r}'
+            )
     residues_binder = [
         bg.Residue(name=aa, chain_ID='BIND', index=i, mutable=True) for i, aa in enumerate(binder_sequence)
     ]

--- a/scripts/car/bgl_sol_cd20_dimer.py
+++ b/scripts/car/bgl_sol_cd20_dimer.py
@@ -1,0 +1,190 @@
+"""
+BAGEL-CAR BGL/SOL CD20-Dimer Binder Design
+
+Designs an 80-residue de novo binder that bridges both monomers of the CD20
+homodimer, contacting the CD20 epitope. This is the BAGEL dimer objective used
+for the BGL and SOL strategies described in the BAGEL-CAR manuscript.
+
+Original design: Nucleate UK London, Bits to Binders competition.
+"""
+
+from __future__ import annotations
+
+import random
+
+import bagel as bg
+import fire
+
+# ---------------------------------------------------------------------------
+# CD20 extracellular domain sequence (169 residues).
+# ---------------------------------------------------------------------------
+CD20_SEQUENCE = (
+    'FMRESKTLGAVQIMNGLFHIALGGLLMIPAGIYAPICVTVWYPLWGGIMYIISGSLLAATE'
+    'KNSRKCLVKGKMIMNSLSLFAAISGMILSIMDILNIKISHFLKMESLNFIRAHTPYINIYN'
+    'CEPANPSEKNSPSTQYCYSIQSLFLGILSVMLIFAFFQELVIAGIVE'
+)
+
+# Epitope groups in PDB-style 1-based residue numbering.
+CD20A_EPITOPE_RESIDUES = range(114, 133)  # His114-Asn132
+CD20B_EPITOPE_RESIDUES = range(114, 132)  # His114-Lys131
+# The one-residue CD20B truncation is retained for provenance.
+POSITION_IDS_SKIP = 512
+GLYCINE_LINKER = 'G' * 25
+AMINO_ACIDS_NO_CYSTEINE = [aa for aa in bg.constants.aa_dict if aa != 'C']
+
+
+def residues_by_pdb_number(residues: list[bg.Residue], pdb_numbers: range) -> list[bg.Residue]:
+    return [residues[pdb_number - 1] for pdb_number in pdb_numbers]
+
+
+def main(
+    use_modal: bool = True,
+    binder_sequence: str | None = None,
+    n_cycles: int = 2000,
+    n_steps_low: int = 200,
+    n_steps_high: int = 200,
+    n_mutations: int = 2,
+    log_frequency: int = 200,
+    log_path: str | None = None,
+) -> bg.System:
+    for name, value in (
+        ('n_cycles', n_cycles),
+        ('n_steps_low', n_steps_low),
+        ('n_steps_high', n_steps_high),
+        ('n_mutations', n_mutations),
+        ('log_frequency', log_frequency),
+    ):
+        if value < 1:
+            raise ValueError(f'{name} must be a positive integer')
+
+    # -- Target chains (CD20 homodimer, both immutable) ---------------------
+    residues_monomer_a = [
+        bg.Residue(name=aa, chain_ID='C20A', index=i, mutable=False) for i, aa in enumerate(CD20_SEQUENCE)
+    ]
+    monomer_a = bg.Chain(residues=residues_monomer_a)
+
+    residues_monomer_b = [
+        bg.Residue(name=aa, chain_ID='C20B', index=i, mutable=False) for i, aa in enumerate(CD20_SEQUENCE)
+    ]
+    monomer_b = bg.Chain(residues=residues_monomer_b)
+
+    epitope_a = residues_by_pdb_number(residues_monomer_a, CD20A_EPITOPE_RESIDUES)
+    epitope_b = residues_by_pdb_number(residues_monomer_b, CD20B_EPITOPE_RESIDUES)
+    epitope_combined = epitope_a + epitope_b
+
+    # -- Binder chain (80 residues, fully mutable) --------------------------
+    binder_length = 80
+    if binder_sequence is None:
+        binder_sequence = ''.join(random.choice(AMINO_ACIDS_NO_CYSTEINE) for _ in range(binder_length))
+    else:
+        if len(binder_sequence) != binder_length:
+            raise ValueError('Binder sequence must be 80 residues')
+        if 'C' in binder_sequence:
+            raise ValueError('Historical initialization excluded cysteine')
+    residues_binder = [
+        bg.Residue(name=aa, chain_ID='BIND', index=i, mutable=True) for i, aa in enumerate(binder_sequence)
+    ]
+    binder_chain = bg.Chain(residues=residues_binder)
+
+    # -- Oracle -------------------------------------------------------------
+    esmfold = bg.oracles.ESMFold(
+        use_modal=use_modal,
+        config={
+            'glycine_linker': GLYCINE_LINKER,
+            'position_ids_skip': POSITION_IDS_SKIP,
+        },
+    )
+
+    # -- Energy terms -------------------------------------------------------
+    energy_terms = [
+        # Global confidence
+        bg.energies.PTMEnergy(
+            oracle=esmfold,
+            weight=0.2,
+        ),
+        # Per-chain folding quality
+        bg.energies.PLDDTEnergy(
+            oracle=esmfold,
+            residues=residues_monomer_a,
+            weight=1.0,
+            name='cd20a',
+        ),
+        bg.energies.PLDDTEnergy(
+            oracle=esmfold,
+            residues=residues_monomer_b,
+            weight=1.0,
+            name='cd20b',
+        ),
+        bg.energies.PLDDTEnergy(
+            oracle=esmfold,
+            residues=residues_binder,
+            weight=1.0,
+            name='binder',
+        ),
+        # Dimer interface confidence
+        bg.energies.PAEEnergy(
+            oracle=esmfold,
+            residues=[residues_monomer_a, residues_monomer_b],
+            weight=2.0,
+            name='cd20a_cd20b',
+        ),
+        # Binder-epitope binding confidence (both monomers)
+        bg.energies.PAEEnergy(
+            oracle=esmfold,
+            residues=[epitope_a, residues_binder],
+            weight=2.0,
+            name='epitope_a_binder',
+        ),
+        bg.energies.PAEEnergy(
+            oracle=esmfold,
+            residues=[epitope_b, residues_binder],
+            weight=2.0,
+            name='epitope_b_binder',
+        ),
+        # Original implementation used a term that averaged all
+        # cross-group backbone atom-pair distances; current SeparationEnergy
+        # uses the distance between group centroids instead.
+        bg.energies.SeparationEnergy(
+            oracle=esmfold,
+            residues=[epitope_combined, residues_binder],
+            weight=1.0,
+            name='epitopes_binder',
+        ),
+        # Binder hydrophobicity penalty
+        bg.energies.HydrophobicEnergy(
+            oracle=esmfold,
+            residues=residues_binder,
+            weight=1.0,
+            name='binder',
+        ),
+    ]
+
+    # -- State & System -----------------------------------------------------
+    state = bg.State(
+        name='cd20_dimer',
+        chains=[monomer_a, monomer_b, binder_chain],
+        energy_terms=energy_terms,
+    )
+    system = bg.System(states=[state])
+
+    # -- Minimizer ----------------------------------------------------------
+    # Original implementation made up to 2 mutations (choosing randomly
+    # between 1 or 2 mutations at any MC step) and did not exclude self-substitutions.
+    minimizer = bg.minimizer.SimulatedTempering(
+        mutator=bg.mutation.Canonical(n_mutations=n_mutations, exclude_self=False),
+        high_temperature=1.0,
+        low_temperature=0.1,
+        n_cycles=n_cycles,
+        n_steps_low=n_steps_low,
+        n_steps_high=n_steps_high,
+        preserve_best_system_every_n_steps=n_steps_low + n_steps_high,
+        log_path=log_path,
+        log_frequency=log_frequency,
+    )
+
+    best_system = minimizer.minimize_system(system=system)
+    return best_system
+
+
+if __name__ == '__main__':
+    fire.Fire(main)

--- a/scripts/car/lnk_cd20_monomer.py
+++ b/scripts/car/lnk_cd20_monomer.py
@@ -54,6 +54,8 @@ def main(
         ('n_mutations', n_mutations),
         ('log_frequency', log_frequency),
     ):
+        if not isinstance(value, int):
+            raise TypeError(f'{name} must be an integer')
         if value < 1:
             raise ValueError(f'{name} must be a positive integer')
 
@@ -69,13 +71,18 @@ def main(
 
     # -- Binder chain (20 residues, fully mutable) --------------------------
     binder_length = 20
+    allowed_residues = set(AMINO_ACIDS_NO_CYSTEINE)
     if binder_sequence is None:
         binder_sequence = ''.join(random.choice(AMINO_ACIDS_NO_CYSTEINE) for _ in range(binder_length))
     else:
         if len(binder_sequence) != binder_length:
-            raise ValueError('Binder sequence must be 20 residues')
-        if 'C' in binder_sequence:
-            raise ValueError('Historical initialization excluded cysteine')
+            raise ValueError(f'binder_sequence must be {binder_length} residues, got {len(binder_sequence)}')
+        invalid = set(binder_sequence) - allowed_residues
+        if invalid:
+            raise ValueError(
+                f'binder_sequence contains invalid residues {sorted(invalid)!r}; '
+                f'allowed (uppercase, cysteine excluded): {sorted(allowed_residues)!r}'
+            )
     residues_binder = [
         bg.Residue(name=aa, chain_ID='BIND', index=i, mutable=True) for i, aa in enumerate(binder_sequence)
     ]

--- a/scripts/car/lnk_cd20_monomer.py
+++ b/scripts/car/lnk_cd20_monomer.py
@@ -1,0 +1,168 @@
+"""
+BAGEL-CAR LNK Monomer Design
+
+Designs a 20-residue peptide binder against a single CD20 monomer epitope
+(His114-Asn132 of the extracellular domain). This is the first stage of the
+LNK pipeline described in the BAGEL-CAR manuscript: BAGEL-derived monomer
+seeds are later connected via RFdiffusion linker design and SolubleMPNN
+sequence optimisation.
+
+Original design: Nucleate UK London, Bits to Binders competition.
+"""
+
+from __future__ import annotations
+
+import random
+
+import bagel as bg
+import fire
+
+# ---------------------------------------------------------------------------
+# CD20 extracellular domain sequence (169 residues).
+# ---------------------------------------------------------------------------
+CD20_SEQUENCE = (
+    'FMRESKTLGAVQIMNGLFHIALGGLLMIPAGIYAPICVTVWYPLWGGIMYIISGSLLAATE'
+    'KNSRKCLVKGKMIMNSLSLFAAISGMILSIMDILNIKISHFLKMESLNFIRAHTPYINIYN'
+    'CEPANPSEKNSPSTQYCYSIQSLFLGILSVMLIFAFFQELVIAGIVE'
+)
+
+# Epitope group in PDB-style 1-based residue numbering.
+EPITOPE_RESIDUES = range(114, 133)  # His114-Asn132
+POSITION_IDS_SKIP = 512
+GLYCINE_LINKER = 'G' * 25
+AMINO_ACIDS_NO_CYSTEINE = [aa for aa in bg.constants.aa_dict if aa != 'C']
+
+
+def residues_by_pdb_number(residues: list[bg.Residue], pdb_numbers: range) -> list[bg.Residue]:
+    return [residues[pdb_number - 1] for pdb_number in pdb_numbers]
+
+
+def main(
+    use_modal: bool = True,
+    binder_sequence: str | None = None,
+    n_cycles: int = 2000,
+    n_steps_low: int = 200,
+    n_steps_high: int = 200,
+    n_mutations: int = 2,
+    log_frequency: int = 200,
+    log_path: str | None = None,
+) -> bg.System:
+    for name, value in (
+        ('n_cycles', n_cycles),
+        ('n_steps_low', n_steps_low),
+        ('n_steps_high', n_steps_high),
+        ('n_mutations', n_mutations),
+        ('log_frequency', log_frequency),
+    ):
+        if value < 1:
+            raise ValueError(f'{name} must be a positive integer')
+
+    # -- Target chain (CD20 monomer, fully immutable) -----------------------
+    residues_target = [
+        bg.Residue(name=aa, chain_ID='CD20', index=i, mutable=False) for i, aa in enumerate(CD20_SEQUENCE)
+    ]
+    target_chain = bg.Chain(residues=residues_target)
+
+    residues_epitope = residues_by_pdb_number(residues_target, EPITOPE_RESIDUES)
+    epitope_residue_indices = {residue.index for residue in residues_epitope}
+    residues_non_epitope = [r for r in residues_target if r.index not in epitope_residue_indices]
+
+    # -- Binder chain (20 residues, fully mutable) --------------------------
+    binder_length = 20
+    if binder_sequence is None:
+        binder_sequence = ''.join(random.choice(AMINO_ACIDS_NO_CYSTEINE) for _ in range(binder_length))
+    else:
+        if len(binder_sequence) != binder_length:
+            raise ValueError('Binder sequence must be 20 residues')
+        if 'C' in binder_sequence:
+            raise ValueError('Historical initialization excluded cysteine')
+    residues_binder = [
+        bg.Residue(name=aa, chain_ID='BIND', index=i, mutable=True) for i, aa in enumerate(binder_sequence)
+    ]
+    binder_chain = bg.Chain(residues=residues_binder)
+
+    # -- Oracle -------------------------------------------------------------
+    esmfold = bg.oracles.ESMFold(
+        use_modal=use_modal,
+        config={
+            'glycine_linker': GLYCINE_LINKER,
+            'position_ids_skip': POSITION_IDS_SKIP,
+        },
+    )
+
+    # -- Energy terms -------------------------------------------------------
+    energy_terms = [
+        bg.energies.PTMEnergy(
+            oracle=esmfold,
+            weight=0.2,
+        ),
+        bg.energies.PLDDTEnergy(
+            oracle=esmfold,
+            residues=residues_non_epitope,
+            weight=0.2,
+            name='cd20_non_epitope',
+        ),
+        bg.energies.PLDDTEnergy(
+            oracle=esmfold,
+            residues=residues_epitope,
+            weight=1.0,
+            name='cd20_epitope',
+        ),
+        bg.energies.PLDDTEnergy(
+            oracle=esmfold,
+            residues=residues_binder,
+            weight=1.0,
+            name='binder',
+        ),
+        bg.energies.PAEEnergy(
+            oracle=esmfold,
+            residues=[residues_epitope, residues_binder],
+            weight=2.0,
+            name='epitope_binder',
+        ),
+        # Original implementation used a term that averaged all
+        # cross-group backbone atom-pair distances; current SeparationEnergy
+        # uses the distance between group centroids instead.
+        bg.energies.SeparationEnergy(
+            oracle=esmfold,
+            residues=[residues_epitope, residues_binder],
+            weight=1.0,
+            name='epitope_binder',
+        ),
+        bg.energies.HydrophobicEnergy(
+            oracle=esmfold,
+            residues=residues_binder,
+            weight=1.0,
+            name='binder',
+        ),
+    ]
+
+    # -- State & System -----------------------------------------------------
+    state = bg.State(
+        name='cd20_monomer',
+        chains=[target_chain, binder_chain],
+        energy_terms=energy_terms,
+    )
+    system = bg.System(states=[state])
+
+    # -- Minimizer ----------------------------------------------------------
+    # Original implementation made up to 2 mutations (choosing randomly
+    # between 1 or 2 mutations at any MC step) and did not exclude self-substitutions.
+    minimizer = bg.minimizer.SimulatedTempering(
+        mutator=bg.mutation.Canonical(n_mutations=n_mutations, exclude_self=False),
+        high_temperature=1.0,
+        low_temperature=0.1,
+        n_cycles=n_cycles,
+        n_steps_low=n_steps_low,
+        n_steps_high=n_steps_high,
+        preserve_best_system_every_n_steps=n_steps_low + n_steps_high,
+        log_path=log_path,
+        log_frequency=log_frequency,
+    )
+
+    best_system = minimizer.minimize_system(system=system)
+    return best_system
+
+
+if __name__ == '__main__':
+    fire.Fire(main)

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "biobagel"
-version = "0.1.12"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
## Summary
Adds the manuscript-facing BAGEL-CAR recipe scripts under `scripts/car/`:

- `bgl_sol_cd20_dimer.py` — the CD20-dimer objective used for the `BGL` strategy and as the source backbone objective for `SOL` (80-residue de novo binder bridging both CD20 monomers).
- `lnk_cd20_monomer.py` — the CD20-monomer seed objective used as the first stage of the `LNK` RFdiffusion linker-fusion pipeline (20-residue seed against the His114-Asn132 epitope).

Labels follow the manuscript (`BGL`, `SOL`, `LNK-*`, `CD20A`, `CD20B`, `binder`). The dimer script uses BAGEL-compatible chain IDs (`C20A`, `C20B`, `BIND`) because BAGEL restricts AtomArray chain IDs to fewer than five characters.

Original design: Nucleate UK London, Bits to Binders competition.

## Verification
- `BAGEL_SKIP_MODEL_SETUP=1 uv run --frozen python -m py_compile scripts/car/*.py`
- `uv run --frozen ruff check scripts/car/`
- Imports resolve against current `main` (`bg.oracles.ESMFold`, `bg.minimizer.SimulatedTempering`, `bg.mutation.Canonical`, `bg.energies.*`)
- Modal smoke (each script):
  `uv run python scripts/car/<script>.py --use_modal=True --n_cycles=1 --n_steps_low=1 --n_steps_high=1 --log_frequency=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two CD20-targeted binder design recipes: one for homodimer interface design (80-residue binder) and one for monomer epitope design (20-residue binder).
  * Added CLI support for both design recipes.

* **Documentation**
  * Added comprehensive guide documenting CAR design recipes with usage instructions for Modal-based and local execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softnanolab/bagel/pull/130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->