### PR TITLE
feat: add ESM-C and ESMFold2 oracles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.1.14"
+version = "0.1.15"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},

--- a/src/bagel/oracles/__init__.py
+++ b/src/bagel/oracles/__init__.py
@@ -1,6 +1,6 @@
 from .base import Oracle, OracleResult, OraclesResultDict
-from .embedding import EmbeddingOracle, ESM2, ESM2Result
-from .folding import FoldingOracle, ESMFold, ESMFoldResult
+from .embedding import EmbeddingOracle, ESM2, ESM2Result, ESMC, ESMCResult
+from .folding import FoldingOracle, ESMFold, ESMFoldResult, ESMFold2, ESMFold2Result
 
 __all__ = [
     'Oracle',
@@ -8,8 +8,12 @@ __all__ = [
     'OraclesResultDict',
     'ESM2',
     'ESM2Result',
+    'ESMC',
+    'ESMCResult',
     'ESMFold',
     'ESMFoldResult',
+    'ESMFold2',
+    'ESMFold2Result',
     'EmbeddingOracle',
     'FoldingOracle',
 ]

--- a/src/bagel/oracles/embedding/__init__.py
+++ b/src/bagel/oracles/embedding/__init__.py
@@ -1,4 +1,5 @@
 from .base import EmbeddingOracle, EmbeddingResult
 from .esm2 import ESM2, ESM2Result
+from .esmc import ESMC, ESMCResult
 
-__all__ = ['EmbeddingOracle', 'EmbeddingResult', 'ESM2', 'ESM2Result']
+__all__ = ['EmbeddingOracle', 'EmbeddingResult', 'ESM2', 'ESM2Result', 'ESMC', 'ESMCResult']

--- a/src/bagel/oracles/embedding/esm2.py
+++ b/src/bagel/oracles/embedding/esm2.py
@@ -26,9 +26,8 @@ class ESM2Result(EmbeddingResult):
     input_chains: list[Chain]
     embeddings: npt.NDArray[np.float64]
 
-    @classmethod
-    def save_attributes(cls, filepath: pl.Path) -> None:
-        np.savetxt(filepath.with_suffix('.embeddings'), cls.embeddings, fmt='%.6f', header='embeddings')
+    def save_attributes(self, filepath: pl.Path) -> None:
+        np.savetxt(filepath.with_suffix('.embeddings'), self.embeddings, fmt='%.6f', header='embeddings')
 
 
 class ESM2(EmbeddingOracle):

--- a/src/bagel/oracles/embedding/esmc.py
+++ b/src/bagel/oracles/embedding/esmc.py
@@ -49,6 +49,23 @@ class ESMC(EmbeddingOracle):
     config : dict
         Configuration options. Supported keys:
         - model_name: ESM-C model variant (default: "esmc_600m")
+
+    Notes
+    -----
+    Multimers are encoded **jointly**, not per chain. ``_pre_process`` joins the
+    chains with ``':'`` into a single string, which boileroom turns into one
+    ``SEQ1|SEQ2`` sequence (``'|'`` is ESM-C's chain-break token) and runs through
+    a **single forward pass**. Self-attention therefore spans all chains, so a
+    residue's embedding reflects the other chains and differs from the embedding
+    it would get in isolation.
+
+    This also makes the embeddings **order-sensitive**: they are *not* permutation
+    invariant across chain order. ESM-C uses rotary (RoPE) positions assigned over
+    the whole concatenated stream with no per-chain reset, so cross-chain relative
+    positions — and hence attention — change if the chain order changes. Concretely,
+    ``embed([chain_A, chain_B]) != permute(embed([chain_B, chain_A]))``. Treat the
+    order of ``chains`` as meaningful and stable. To obtain isolated per-chain
+    embeddings instead, embed each chain in a separate call.
     """
 
     result_class = ESMCResult

--- a/src/bagel/oracles/embedding/esmc.py
+++ b/src/bagel/oracles/embedding/esmc.py
@@ -30,9 +30,8 @@ class ESMCResult(EmbeddingResult):
     input_chains: list[Chain]
     embeddings: npt.NDArray[np.float64]
 
-    @classmethod
-    def save_attributes(cls, filepath: pl.Path) -> None:
-        np.savetxt(filepath.with_suffix('.embeddings'), cls.embeddings, fmt='%.6f', header='embeddings')
+    def save_attributes(self, filepath: pl.Path) -> None:
+        np.savetxt(filepath.with_suffix('.embeddings'), self.embeddings, fmt='%.6f', header='embeddings')
 
 
 class ESMC(EmbeddingOracle):

--- a/src/bagel/oracles/embedding/esmc.py
+++ b/src/bagel/oracles/embedding/esmc.py
@@ -1,0 +1,110 @@
+"""
+ESMC oracle for computing protein embeddings using EvolutionaryScale's ESM-C models.
+
+The heavy ``boileroom`` model wrappers are imported lazily inside ``_load`` so
+that importing this module (and constructing mocked oracles in tests) does not
+require the ``boileroom.models.esm3`` package to be installed. The ESM-C wrapper
+lives in boileroom >= 0.3.x (``boileroom.models.esm3.esmc``); older pinned
+versions do not ship it.
+"""
+
+import pathlib as pl
+import logging
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+from ...chain import Chain
+from .base import EmbeddingResult, EmbeddingOracle
+
+if TYPE_CHECKING:
+    from boileroom.models.esm3.types import ESMCOutput  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class ESMCResult(EmbeddingResult):
+    """Stores embedding results from ESM-C."""
+
+    input_chains: list[Chain]
+    embeddings: npt.NDArray[np.float64]
+
+    @classmethod
+    def save_attributes(cls, filepath: pl.Path) -> None:
+        np.savetxt(filepath.with_suffix('.embeddings'), cls.embeddings, fmt='%.6f', header='embeddings')
+
+
+class ESMC(EmbeddingOracle):
+    """Oracle that uses ESM-C to compute per-residue embeddings.
+
+    ESM-C (ESM Cambrian) is a protein language model from EvolutionaryScale
+    trained on billions of protein sequences. It supports 300M, 600M, and
+    6B parameter variants.
+
+    Parameters
+    ----------
+    use_modal : bool
+        Whether to run inference remotely via Modal.
+    config : dict
+        Configuration options. Supported keys:
+        - model_name: ESM-C model variant (default: "esmc_600m")
+    """
+
+    result_class = ESMCResult
+
+    def __init__(
+        self,
+        use_modal: bool = False,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        if config is None:
+            config = {}
+        self.use_modal = use_modal
+        self.default_config: dict[str, Any] = {
+            'model_name': 'esmc_600m',
+        }
+        self._load(config)
+
+    def _load(self, config: dict[str, Any] | None = None) -> None:
+        # Imported here (not at module scope) so the module stays importable
+        # without the boileroom ESM-C wrapper present, and so mocked oracles in
+        # tests can patch out _load entirely.
+        from boileroom.models.esm3.esmc import ESMC as ESMCBoiler  # type: ignore
+
+        if config is None:
+            config = {}
+        merged_config = {**self.default_config, **config}
+        backend = 'modal' if self.use_modal else 'apptainer'
+        self.model = ESMCBoiler(backend=backend, config=merged_config)
+
+    def _pre_process(self, chains: list[Chain]) -> list[str]:
+        """Join chains with ':' separator for multimers."""
+        monomers = [chain.sequence for chain in chains]
+        return [':'.join(monomers)]
+
+    def embed(self, chains: list[Chain]) -> ESMCResult:
+        """Compute ESM-C embeddings for the residues in the given chains.
+
+        Parameters
+        ----------
+        chains : list[Chain]
+            List of protein chains to embed.
+
+        Returns
+        -------
+        ESMCResult
+            Embedding result with per-residue embeddings.
+        """
+        self.input_chains = chains
+        processed_chains = self._pre_process(chains)
+        output = self.model.embed(processed_chains)
+        return self._post_process(output)
+
+    def _post_process(self, output: 'ESMCOutput') -> ESMCResult:
+        embeddings = output.embeddings[0, :, :]
+        assert len(embeddings.shape) == 2, (
+            f'Embeddings is expected to be a 2D tensor, not shape: {embeddings.shape}. '
+            'The ESMC Oracle does not support batches.'
+        )
+        return self.result_class(input_chains=self.input_chains, embeddings=embeddings)

--- a/src/bagel/oracles/folding/__init__.py
+++ b/src/bagel/oracles/folding/__init__.py
@@ -1,4 +1,5 @@
 from .base import FoldingResult, FoldingOracle
 from .esmfold import ESMFold, ESMFoldResult
+from .esmfold2 import ESMFold2, ESMFold2Result
 
-__all__ = ['FoldingOracle', 'FoldingResult', 'ESMFold', 'ESMFoldResult']
+__all__ = ['FoldingOracle', 'FoldingResult', 'ESMFold', 'ESMFoldResult', 'ESMFold2', 'ESMFold2Result']

--- a/src/bagel/oracles/folding/esmfold.py
+++ b/src/bagel/oracles/folding/esmfold.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.typing as npt
 from ...chain import Chain
 from ...constants import atom_order
-from .utils import reindex_chains
+from .utils import reindex_chains, validate_array_range
 from pydantic import field_validator
 from .base import FoldingOracle, FoldingResult
 from typing import List, Any, Type
@@ -21,25 +21,6 @@ from biotite.structure import AtomArray
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-def validate_array_range(
-    array: npt.NDArray[np.float64], field_name: str, min_val: float = 0, max_val: float = 1
-) -> npt.NDArray[np.float64]:
-    """
-    Validates that an array is a numpy array and its values fall within the specified range.
-
-    Args:
-        array: Array to validate
-        field_name: Name of the field for error messages
-        min_val: Minimum allowed value (inclusive)
-        max_val: Maximum allowed value (inclusive)
-    """
-    if not isinstance(array, np.ndarray):
-        raise ValueError(f'{field_name} must be a numpy array')
-    if not np.all((array >= min_val) & (array <= max_val)):
-        raise ValueError(f'All values in {field_name} must be between {min_val} and {max_val}')
-    return array
 
 
 class ESMFoldResult(FoldingResult):

--- a/src/bagel/oracles/folding/esmfold2.py
+++ b/src/bagel/oracles/folding/esmfold2.py
@@ -78,20 +78,28 @@ class ESMFold2Result(FoldingResult):
 class ESMFold2(FoldingOracle):
     """Oracle that uses ESMFold2 to predict protein structures from sequence.
 
-    ESMFold2 is a diffusion-based structure prediction model from
-    EvolutionaryScale. It uses the Biohub Forge API for inference.
-    Set the ``ESM_API_KEY`` environment variable to authenticate.
+    ESMFold2 is a diffusion-based all-atom structure prediction model from
+    EvolutionaryScale. The boileroom wrapper runs it **locally** on the selected
+    backend (Modal GPU or Apptainer): model weights are loaded from Hugging Face
+    (``biohub/ESMFold2``) and inference runs in-process. No inference API or API
+    token is involved.
+
+    Multimers are handled **natively** as separate chains — ESMFold2 does not use
+    a glycine linker or a positional-id skip. ``_pre_process`` serializes the
+    chains as a ``':'``-delimited string, which the boileroom wrapper parses back
+    into distinct per-chain entities.
 
     Parameters
     ----------
     use_modal : bool
-        Whether to run the boileroom wrapper via Modal.
+        Whether to run the boileroom wrapper via the Modal backend (otherwise
+        Apptainer).
     config : dict
-        Configuration options. Supported keys:
-        - model_name: ESMFold2 model variant (default: "esmfold2-fast-2026-05")
-        - api_token: Biohub API token (or set ESM_API_KEY env var)
-        - num_sampling_steps: Diffusion steps (default: 100)
-        - num_loops: Refinement loops (default: 20)
+        Configuration options forwarded to the boileroom ESMFold2 wrapper.
+        Supported keys include:
+        - model_name: ESMFold2 weights to load (e.g. "biohub/ESMFold2")
+        - num_sampling_steps: Diffusion sampling steps
+        - num_loops: Refinement loops
     """
 
     result_class: Type[ESMFold2Result] = ESMFold2Result

--- a/src/bagel/oracles/folding/esmfold2.py
+++ b/src/bagel/oracles/folding/esmfold2.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ...chain import Chain
-from .utils import reindex_chains
+from .utils import reindex_chains, validate_array_range
 from pydantic import field_validator
 from .base import FoldingOracle, FoldingResult
 
@@ -26,17 +26,6 @@ if TYPE_CHECKING:
     from boileroom.models.esmfold2.types import ESMFold2Output  # type: ignore
 
 logger = logging.getLogger(__name__)
-
-
-def validate_array_range(
-    array: npt.NDArray[np.float64], field_name: str, min_val: float = 0, max_val: float = 1
-) -> npt.NDArray[np.float64]:
-    """Validate that an array's values fall within a specified range."""
-    if not isinstance(array, np.ndarray):
-        raise ValueError(f'{field_name} must be a numpy array')
-    if not np.all((array >= min_val) & (array <= max_val)):
-        raise ValueError(f'All values in {field_name} must be between {min_val} and {max_val}')
-    return array
 
 
 class ESMFold2Result(FoldingResult):
@@ -186,7 +175,7 @@ class ESMFold2(FoldingOracle):
         atoms = reindex_chains(atoms, [chain.chain_ID for chain in chains])
 
         # Extract pLDDT - ESMFold2 returns per-residue pLDDT directly
-        local_plddt = np.array([0.0])  # default
+        local_plddt = np.array([[0.0]])  # default (1, N) to match ptm/pae and save_attributes
         if output.plddt is not None and len(output.plddt) > 0 and output.plddt[0] is not None:
             local_plddt = output.plddt[0]
             if local_plddt.ndim == 1:

--- a/src/bagel/oracles/folding/esmfold2.py
+++ b/src/bagel/oracles/folding/esmfold2.py
@@ -85,9 +85,10 @@ class ESMFold2(FoldingOracle):
     token is involved.
 
     Multimers are handled **natively** as separate chains — ESMFold2 does not use
-    a glycine linker or a positional-id skip. ``_pre_process`` serializes the
-    chains as a ``':'``-delimited string, which the boileroom wrapper parses back
-    into distinct per-chain entities.
+    a glycine linker or a positional-id skip. ``_pre_process`` builds a structured
+    boileroom fold input (one protein entity per chain) so ESMFold2 receives
+    bagel's own ``chain_ID``s directly, rather than the auto-assigned ``A``/``B``/
+    ``C`` labels produced by the ``':'``-delimited string shortcut.
 
     Parameters
     ----------
@@ -131,10 +132,23 @@ class ESMFold2(FoldingOracle):
         backend = 'modal' if self.use_modal else 'apptainer'
         self.model = ESMFold2Boiler(backend=backend, config=merged_config)
 
-    def _pre_process(self, chains: list[Chain]) -> list[str]:
-        """Join chains with ':' for multimers."""
-        monomers = [chain.sequence for chain in chains]
-        return [':'.join(monomers)]
+    def _pre_process(self, chains: list[Chain]) -> dict[str, Any]:
+        """Build a structured ESMFold2 fold input that preserves each ``chain_ID``.
+
+        Returns a single ``StructurePredictionInput``-shaped dict describing one
+        complex, with one protein entity per chain keyed by the chain's own
+        ``chain_ID``. Using structured input (instead of a ``':'``-joined string)
+        makes ESMFold2 fold the chains as a single complex while receiving bagel's
+        chain IDs directly, and leaves room for non-protein entities later.
+
+        It is emitted as a plain dict — boileroom's public ``dict`` fold input — so
+        no boileroom 0.3.x type import is required here. A *single* mapping is one
+        complex; a list of mappings would instead be treated as a batch of separate
+        structures, which is why the chains are nested under one ``sequences`` key.
+        """
+        return {
+            'sequences': [{'kind': 'protein', 'id': chain.chain_ID, 'sequence': chain.sequence} for chain in chains]
+        }
 
     def fold(self, chains: list[Chain]) -> ESMFold2Result:
         """Fold a list of chains using ESMFold2.

--- a/src/bagel/oracles/folding/esmfold2.py
+++ b/src/bagel/oracles/folding/esmfold2.py
@@ -1,0 +1,193 @@
+"""
+ESMFold2 oracle for protein structure prediction using EvolutionaryScale's ESMFold2.
+
+The heavy ``boileroom`` model wrapper is imported lazily inside ``_load`` so that
+importing this module (and constructing mocked oracles in tests) does not require
+the ``boileroom.models.esmfold2`` package to be installed. The ESMFold2 wrapper
+lives in boileroom >= 0.3.x (``boileroom.models.esmfold2.esmfold2``); older pinned
+versions do not ship it.
+"""
+
+import pathlib as pl
+import logging
+from typing import TYPE_CHECKING, Any, Type
+
+import numpy as np
+import numpy.typing as npt
+
+from ...chain import Chain
+from .utils import reindex_chains
+from pydantic import field_validator
+from .base import FoldingOracle, FoldingResult
+
+from biotite.structure import AtomArray
+
+if TYPE_CHECKING:
+    from boileroom.models.esmfold2.types import ESMFold2Output  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def validate_array_range(
+    array: npt.NDArray[np.float64], field_name: str, min_val: float = 0, max_val: float = 1
+) -> npt.NDArray[np.float64]:
+    """Validate that an array's values fall within a specified range."""
+    if not isinstance(array, np.ndarray):
+        raise ValueError(f'{field_name} must be a numpy array')
+    if not np.all((array >= min_val) & (array <= max_val)):
+        raise ValueError(f'All values in {field_name} must be between {min_val} and {max_val}')
+    return array
+
+
+class ESMFold2Result(FoldingResult):
+    """Stores statistics from the ESMFold2 structure prediction.
+
+    Attributes
+    ----------
+    input_chains : list[Chain]
+        The input chains that were folded.
+    structure : AtomArray
+        The predicted 3D structure.
+    local_plddt : npt.NDArray[np.float64]
+        Per-residue pLDDT confidence scores (0 to 1).
+    ptm : npt.NDArray[np.float64]
+        Predicted Template Modelling score (0 to 1).
+    pae : npt.NDArray[np.float64]
+        Predicted Aligned Error matrix.
+    """
+
+    input_chains: list[Chain]
+    structure: AtomArray
+    local_plddt: npt.NDArray[np.float64]
+    ptm: npt.NDArray[np.float64]
+    pae: npt.NDArray[np.float64]
+
+    @field_validator('local_plddt')
+    def validate_local_plddt(cls, v: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return validate_array_range(v, 'local_plddt', 0, 1)
+
+    @field_validator('ptm')
+    def validate_ptm(cls, v: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return validate_array_range(v, 'ptm', 0, 1)
+
+    def save_attributes(self, filepath: pl.Path) -> None:
+        np.savetxt(filepath.with_suffix('.plddt'), self.local_plddt[0], fmt='%.6f', header='plddt')
+        np.savetxt(filepath.with_suffix('.pae'), self.pae[0], fmt='%.6f', header='pae')
+
+
+class ESMFold2(FoldingOracle):
+    """Oracle that uses ESMFold2 to predict protein structures from sequence.
+
+    ESMFold2 is a diffusion-based structure prediction model from
+    EvolutionaryScale. It uses the Biohub Forge API for inference.
+    Set the ``ESM_API_KEY`` environment variable to authenticate.
+
+    Parameters
+    ----------
+    use_modal : bool
+        Whether to run the boileroom wrapper via Modal.
+    config : dict
+        Configuration options. Supported keys:
+        - model_name: ESMFold2 model variant (default: "esmfold2-fast-2026-05")
+        - api_token: Biohub API token (or set ESM_API_KEY env var)
+        - num_sampling_steps: Diffusion steps (default: 100)
+        - num_loops: Refinement loops (default: 20)
+    """
+
+    result_class: Type[ESMFold2Result] = ESMFold2Result
+
+    def __init__(
+        self,
+        use_modal: bool = False,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        if config is None:
+            config = {}
+        self.use_modal = use_modal
+        self.default_config: dict[str, Any] = {
+            'model_name': 'esmfold2-fast-2026-05',
+            'num_sampling_steps': 100,
+            'num_loops': 20,
+        }
+        self._load(config)
+
+    def _load(self, config: dict[str, Any] | None = None) -> None:
+        # Imported here (not at module scope) so the module stays importable
+        # without the boileroom ESMFold2 wrapper present, and so mocked oracles in
+        # tests can patch out _load entirely.
+        from boileroom.models.esmfold2.esmfold2 import ESMFold2 as ESMFold2Boiler  # type: ignore
+
+        if config is None:
+            config = {}
+        merged_config = {**self.default_config, **config}
+        backend = 'modal' if self.use_modal else 'apptainer'
+        self.model = ESMFold2Boiler(backend=backend, config=merged_config)
+
+    def _pre_process(self, chains: list[Chain]) -> list[str]:
+        """Join chains with ':' for multimers."""
+        monomers = [chain.sequence for chain in chains]
+        return [':'.join(monomers)]
+
+    def fold(self, chains: list[Chain]) -> ESMFold2Result:
+        """Fold a list of chains using ESMFold2.
+
+        Parameters
+        ----------
+        chains : list[Chain]
+            List of protein chains to fold.
+
+        Returns
+        -------
+        ESMFold2Result
+            Folding result with structure and confidence metrics.
+        """
+        output = self.model.fold(self._pre_process(chains))
+        return self._reduce_output(output, chains)
+
+    def _reduce_output(self, output: 'ESMFold2Output', chains: list[Chain]) -> ESMFold2Result:
+        """Convert ESMFold2Output to ESMFold2Result.
+
+        Parameters
+        ----------
+        output : ESMFold2Output
+            Raw output from the boileroom wrapper.
+        chains : list[Chain]
+            Original input chains for chain reindexing.
+
+        Returns
+        -------
+        ESMFold2Result
+            Reduced result with relevant metrics.
+        """
+        # boileroom >= 0.3.x returns atom_array as a list (one AtomArray per input).
+        atoms = output.atom_array[0] if isinstance(output.atom_array, (list, tuple)) else output.atom_array
+        atoms = reindex_chains(atoms, [chain.chain_ID for chain in chains])
+
+        # Extract pLDDT - ESMFold2 returns per-residue pLDDT directly
+        local_plddt = np.array([0.0])  # default
+        if output.plddt is not None and len(output.plddt) > 0 and output.plddt[0] is not None:
+            local_plddt = output.plddt[0]
+            if local_plddt.ndim == 1:
+                local_plddt = local_plddt[None, :]  # add batch dim
+
+        # Extract PTM
+        ptm = np.array([[0.0]])
+        if output.ptm is not None and len(output.ptm) > 0 and output.ptm[0] is not None:
+            ptm = output.ptm[0]
+            if ptm.ndim == 1:
+                ptm = ptm[None, :]
+
+        # Extract PAE
+        pae = np.zeros((1, 0, 0))
+        if output.pae is not None:
+            pae = output.pae
+            if pae.ndim == 2:
+                pae = pae[None, :, :]
+
+        return self.result_class(
+            input_chains=chains,
+            structure=atoms,
+            local_plddt=local_plddt,
+            ptm=ptm,
+            pae=pae,
+        )

--- a/src/bagel/oracles/folding/utils.py
+++ b/src/bagel/oracles/folding/utils.py
@@ -5,6 +5,7 @@ from io import StringIO
 
 import pandas as pd  # This is necessary because its "unique" method does not sort elements and leaves them as they are
 import numpy as np
+import numpy.typing as npt
 from biotite.structure import AtomArray
 from biotite.structure.io.pdb import PDBFile
 
@@ -96,3 +97,22 @@ def reorder_atoms_in_template(atom_array: AtomArray) -> AtomArray:
         reordered_indices.extend(sorted_indices)
 
     return atom_array[reordered_indices]
+
+
+def validate_array_range(
+    array: npt.NDArray[np.float64], field_name: str, min_val: float = 0, max_val: float = 1
+) -> npt.NDArray[np.float64]:
+    """
+    Validates that an array is a numpy array and its values fall within the specified range.
+
+    Args:
+        array: Array to validate
+        field_name: Name of the field for error messages
+        min_val: Minimum allowed value (inclusive)
+        max_val: Maximum allowed value (inclusive)
+    """
+    if not isinstance(array, np.ndarray):
+        raise ValueError(f'{field_name} must be a numpy array')
+    if not np.all((array >= min_val) & (array <= max_val)):
+        raise ValueError(f'All values in {field_name} must be between {min_val} and {max_val}')
+    return array

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,55 @@ def esm2(request, modal_app_context) -> bg.oracles.embedding.ESM2:
 
 
 @pytest.fixture
+def fake_esmc(request, monkeypatch) -> bg.oracles.embedding.ESMC:
+    """Fixture that returns an ESMC object that doesn't load any model."""
+
+    def mock_load(self, config={}):
+        pass
+
+    monkeypatch.setattr(bg.oracles.embedding.ESMC, '_load', mock_load)
+    return bg.oracles.embedding.ESMC()
+
+
+@pytest.fixture
+def fake_esmfold2(request, monkeypatch) -> bg.oracles.folding.ESMFold2:
+    """Fixture that returns an ESMFold2 object that doesn't load any model."""
+
+    def mock_load(self, config={}):
+        pass
+
+    def mock_fold(self, chains):
+        atoms_list = []
+        for chain in chains:
+            for residue in chain.residues:
+                atom = Atom(
+                    coord=[0.0, 0.0, 0.0],
+                    chain_id=chain.chain_ID,
+                    res_id=residue.index,
+                    res_name=bg.constants.aa_dict.get(residue.name, 'GLY'),
+                    atom_name='CA',
+                    element='C',
+                )
+                atoms_list.append(atom)
+
+        mock_structure = array(atoms_list) if atoms_list else AtomArray(0)
+        num_residues = sum(len(chain.residues) for chain in chains) if chains else 0
+
+        return bg.oracles.folding.ESMFold2Result(
+            input_chains=chains,
+            structure=mock_structure,
+            local_plddt=np.zeros((1, num_residues)) if num_residues > 0 else np.array([]).reshape(1, 0),
+            ptm=np.array([0.5])[None, :],
+            pae=np.zeros((1, num_residues, num_residues)) if num_residues > 0 else np.zeros((1, 0, 0)),
+        )
+
+    monkeypatch.setattr(bg.oracles.folding.ESMFold2, '_load', mock_load)
+    monkeypatch.setattr(bg.oracles.folding.ESMFold2, 'fold', mock_fold)
+
+    return bg.oracles.folding.ESMFold2()
+
+
+@pytest.fixture
 def fake_esm2(request, monkeypatch) -> bg.oracles.embedding.ESM2:
     """
     Fixture that returns an ESM2 object that doesn't load any model.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,34 @@ def fake_esmc(request, monkeypatch) -> bg.oracles.embedding.ESMC:
     return bg.oracles.embedding.ESMC()
 
 
+def _build_mock_fold_result(result_class, chains):
+    """Build a mock folding result (CA-only structure + zeroed confidence arrays) for ``chains``."""
+    atoms_list = []
+    for chain in chains:
+        for residue in chain.residues:
+            atoms_list.append(
+                Atom(
+                    coord=[0.0, 0.0, 0.0],
+                    chain_id=chain.chain_ID,
+                    res_id=residue.index,
+                    res_name=bg.constants.aa_dict.get(residue.name, 'GLY'),
+                    atom_name='CA',
+                    element='C',
+                )
+            )
+
+    mock_structure = array(atoms_list) if atoms_list else AtomArray(0)
+    num_residues = sum(len(chain.residues) for chain in chains) if chains else 0
+
+    return result_class(
+        input_chains=chains,
+        structure=mock_structure,
+        local_plddt=np.zeros((1, num_residues)) if num_residues > 0 else np.array([]).reshape(1, 0),
+        ptm=np.array([0.5])[None, :],
+        pae=np.zeros((1, num_residues, num_residues)) if num_residues > 0 else np.zeros((1, 0, 0)),
+    )
+
+
 @pytest.fixture
 def fake_esmfold2(request, monkeypatch) -> bg.oracles.folding.ESMFold2:
     """Fixture that returns an ESMFold2 object that doesn't load any model."""
@@ -107,29 +135,7 @@ def fake_esmfold2(request, monkeypatch) -> bg.oracles.folding.ESMFold2:
         pass
 
     def mock_fold(self, chains):
-        atoms_list = []
-        for chain in chains:
-            for residue in chain.residues:
-                atom = Atom(
-                    coord=[0.0, 0.0, 0.0],
-                    chain_id=chain.chain_ID,
-                    res_id=residue.index,
-                    res_name=bg.constants.aa_dict.get(residue.name, 'GLY'),
-                    atom_name='CA',
-                    element='C',
-                )
-                atoms_list.append(atom)
-
-        mock_structure = array(atoms_list) if atoms_list else AtomArray(0)
-        num_residues = sum(len(chain.residues) for chain in chains) if chains else 0
-
-        return bg.oracles.folding.ESMFold2Result(
-            input_chains=chains,
-            structure=mock_structure,
-            local_plddt=np.zeros((1, num_residues)) if num_residues > 0 else np.array([]).reshape(1, 0),
-            ptm=np.array([0.5])[None, :],
-            pae=np.zeros((1, num_residues, num_residues)) if num_residues > 0 else np.zeros((1, 0, 0)),
-        )
+        return _build_mock_fold_result(bg.oracles.folding.ESMFold2Result, chains)
 
     monkeypatch.setattr(bg.oracles.folding.ESMFold2, '_load', mock_load)
     monkeypatch.setattr(bg.oracles.folding.ESMFold2, 'fold', mock_fold)
@@ -170,34 +176,7 @@ def fake_esmfold(request, monkeypatch) -> bg.oracles.folding.ESMFold:
 
     # Mock the fold method to return a proper ESMFoldResult based on input chains
     def mock_fold(self, chains):
-        # Create an AtomArray with atoms for each residue in each chain
-        atoms_list = []
-        for chain in chains:
-            for residue in chain.residues:
-                # Create at least one atom (CA) per residue with correct chain_id and res_id
-                atom = Atom(
-                    coord=[0.0, 0.0, 0.0],
-                    chain_id=chain.chain_ID,
-                    res_id=residue.index,
-                    res_name=bg.constants.aa_dict.get(residue.name, 'GLY'),
-                    atom_name='CA',
-                    element='C',
-                )
-                atoms_list.append(atom)
-
-        mock_structure = array(atoms_list) if atoms_list else AtomArray(0)
-
-        # Calculate number of residues across all chains
-        num_residues = sum(len(chain.residues) for chain in chains) if chains else 0
-
-        # Return ESMFoldResult with proper structure
-        return bg.oracles.folding.ESMFoldResult(
-            input_chains=chains,
-            structure=mock_structure,
-            local_plddt=np.zeros((1, num_residues)) if num_residues > 0 else np.array([]).reshape(1, 0),
-            ptm=np.array([0.5])[None, :],
-            pae=np.zeros((1, num_residues, num_residues)) if num_residues > 0 else np.zeros((1, 0, 0)),
-        )
+        return _build_mock_fold_result(bg.oracles.folding.ESMFoldResult, chains)
 
     # Patch both methods
     monkeypatch.setattr(bg.oracles.folding.ESMFold, '_load', mock_load)

--- a/tests/unit_tests/test_esmc_oracle.py
+++ b/tests/unit_tests/test_esmc_oracle.py
@@ -1,0 +1,131 @@
+"""Unit tests for ESMC and ESMFold2 oracles."""
+
+import numpy as np
+import pytest
+from biotite.structure import Atom, AtomArray, array
+
+import bagel as bg
+from bagel.oracles.base import OraclesResultDict
+from bagel.oracles.embedding.esmc import ESMC, ESMCResult
+from bagel.oracles.folding.esmfold2 import ESMFold2, ESMFold2Result
+
+
+class TestESMCResult:
+    """Tests for the ESMCResult dataclass."""
+
+    def test_esmc_result_stores_embeddings(self):
+        residues = [bg.Residue(name='A', chain_ID='A', index=0)]
+        chains = [bg.Chain(residues)]
+        embeddings = np.random.randn(5, 128).astype(np.float64)
+        result = ESMCResult(input_chains=chains, embeddings=embeddings)
+        assert result.embeddings.shape == (5, 128)
+        assert result.input_chains == chains
+
+    def test_esmc_result_in_oracles_dict(self):
+        residues = [bg.Residue(name='A', chain_ID='A', index=0)]
+        chains = [bg.Chain(residues)]
+        embeddings = np.random.randn(1, 128).astype(np.float64)
+
+        # Use a mock oracle that has result_class = ESMCResult
+        oracle = ESMC.__new__(ESMC)
+        oracle.result_class = ESMCResult
+        result = ESMCResult(input_chains=chains, embeddings=embeddings)
+
+        oracles_result = OraclesResultDict()
+        oracles_result[oracle] = result
+        assert oracles_result.get_embeddings(oracle).shape == (1, 128)
+
+
+class TestESMFold2Result:
+    """Tests for the ESMFold2Result dataclass."""
+
+    def test_esmfold2_result_validates_plddt_range(self):
+        residues = [bg.Residue(name='A', chain_ID='A', index=0)]
+        chains = [bg.Chain(residues)]
+        mock_structure = array(
+            [Atom(coord=[0.0, 0.0, 0.0], chain_id='A', res_id=0, res_name='ALA', atom_name='CA', element='C')]
+        )
+
+        # Valid pLDDT values (0 to 1)
+        result = ESMFold2Result(
+            input_chains=chains,
+            structure=mock_structure,
+            local_plddt=np.array([[0.5]]),
+            ptm=np.array([[0.7]]),
+            pae=np.zeros((1, 1, 1)),
+        )
+        assert np.allclose(result.local_plddt, 0.5)
+
+    def test_esmfold2_result_rejects_invalid_plddt(self):
+        residues = [bg.Residue(name='A', chain_ID='A', index=0)]
+        chains = [bg.Chain(residues)]
+        mock_structure = array(
+            [Atom(coord=[0.0, 0.0, 0.0], chain_id='A', res_id=0, res_name='ALA', atom_name='CA', element='C')]
+        )
+
+        with pytest.raises(ValueError, match='local_plddt'):
+            ESMFold2Result(
+                input_chains=chains,
+                structure=mock_structure,
+                local_plddt=np.array([[1.5]]),  # out of range
+                ptm=np.array([[0.7]]),
+                pae=np.zeros((1, 1, 1)),
+            )
+
+    def test_esmfold2_result_in_oracles_dict(self):
+        residues = [bg.Residue(name='A', chain_ID='A', index=0)]
+        chains = [bg.Chain(residues)]
+        mock_structure = array(
+            [Atom(coord=[0.0, 0.0, 0.0], chain_id='A', res_id=0, res_name='ALA', atom_name='CA', element='C')]
+        )
+
+        oracle = ESMFold2.__new__(ESMFold2)
+        oracle.result_class = ESMFold2Result
+        result = ESMFold2Result(
+            input_chains=chains,
+            structure=mock_structure,
+            local_plddt=np.array([[0.5]]),
+            ptm=np.array([[0.7]]),
+            pae=np.zeros((1, 1, 1)),
+        )
+
+        oracles_result = OraclesResultDict()
+        oracles_result[oracle] = result
+        returned_structure = oracles_result.get_structure(oracle)
+        assert len(returned_structure) == 1
+
+
+class TestESMCOracle:
+    """Tests for the ESMC oracle class."""
+
+    def test_esmc_result_class(self):
+        assert ESMC.result_class is ESMCResult
+
+    def test_esmc_pre_process_monomer(self, fake_esmc):
+        chains = [bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])]
+        result = fake_esmc._pre_process(chains)
+        assert result == ['AAA']
+
+    def test_esmc_pre_process_multimer(self, fake_esmc):
+        chain_a = bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])
+        chain_b = bg.Chain([bg.Residue(name='G', chain_ID='B', index=i) for i in range(2)])
+        result = fake_esmc._pre_process([chain_a, chain_b])
+        assert result == ['AAA:GG']
+
+
+class TestESMFold2Oracle:
+    """Tests for the ESMFold2 oracle class."""
+
+    def test_esmfold2_result_class(self):
+        assert ESMFold2.result_class is ESMFold2Result
+
+    def test_esmfold2_pre_process_monomer(self, fake_esmfold2):
+        chains = [bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])]
+        result = fake_esmfold2._pre_process(chains)
+        assert result == ['AAA']
+
+    def test_esmfold2_pre_process_multimer(self, fake_esmfold2):
+        chain_a = bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])
+        chain_b = bg.Chain([bg.Residue(name='G', chain_ID='B', index=i) for i in range(2)])
+        result = fake_esmfold2._pre_process([chain_a, chain_b])
+        assert result == ['AAA:GG']

--- a/tests/unit_tests/test_esmc_oracle.py
+++ b/tests/unit_tests/test_esmc_oracle.py
@@ -122,10 +122,21 @@ class TestESMFold2Oracle:
     def test_esmfold2_pre_process_monomer(self, fake_esmfold2):
         chains = [bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])]
         result = fake_esmfold2._pre_process(chains)
-        assert result == ['AAA']
+        assert result == {'sequences': [{'kind': 'protein', 'id': 'A', 'sequence': 'AAA'}]}
 
     def test_esmfold2_pre_process_multimer(self, fake_esmfold2):
         chain_a = bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])
         chain_b = bg.Chain([bg.Residue(name='G', chain_ID='B', index=i) for i in range(2)])
         result = fake_esmfold2._pre_process([chain_a, chain_b])
-        assert result == ['AAA:GG']
+        assert result == {
+            'sequences': [
+                {'kind': 'protein', 'id': 'A', 'sequence': 'AAA'},
+                {'kind': 'protein', 'id': 'B', 'sequence': 'GG'},
+            ]
+        }
+
+    def test_esmfold2_pre_process_preserves_custom_chain_ids(self, fake_esmfold2):
+        chain_a = bg.Chain([bg.Residue(name='A', chain_ID='C-A', index=i) for i in range(2)])
+        chain_b = bg.Chain([bg.Residue(name='G', chain_ID='C-B', index=i) for i in range(2)])
+        result = fake_esmfold2._pre_process([chain_a, chain_b])
+        assert [entity['id'] for entity in result['sequences']] == ['C-A', 'C-B']


### PR DESCRIPTION
## Summary
Adds bagel oracles wrapping boileroom's **ESM-C** embedding model and **ESMFold2** structure predictor, mirroring the existing ESM2/ESMFold oracles.

## Changes
- **`ESMC`** (embedding) and **`ESMFold2`** (folding) oracle classes + result types, exported from `bagel.oracles`.
- boileroom wrappers imported **lazily** inside `_load`, targeting the boileroom module paths `boileroom.models.esm3.esmc` and `boileroom.models.esmfold2.esmfold2`, so the modules stay importable on the currently pinned boileroom (0.2.2) and activate once the boileroom pin is bumped.
- ESM-C oracle docstring documents that multimers are encoded **jointly** (single forward pass, cross-chain attention) and are therefore **order-sensitive** (not permutation-invariant).
- ESMFold2 oracle passes **structured input** (one protein entity per chain, keyed by `chain_ID`) instead of a `:`-joined string, so ESMFold2 receives bagel's own chain IDs and native multi-chain handling; docstring corrected to note ESMFold2 runs **locally** (no inference API/token).
- Mock-based unit tests (`fake_esmc` / `fake_esmfold2`) plus decoder/wiring tests. Full bagel unit suite green (**111 passed, 4 skipped**), ruff clean.

## Blocked on
Real use needs a boileroom release exposing these modules (target **0.4.1**, boileroom PR `feat/esm3-sasa-output` and the merged ESM-C/ESMFold2 work) and a bump of bagel's `boileroom` pin. **Draft until then.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new embedding oracle (ESMC) with embedding output saving.
  * Added a new folding oracle (ESMFold2) returning confidence metrics (local pLDDT, pTM, PAE) and supporting result file export.
  * Improved multi-chain preprocessing, including preservation of chain identifiers.
* **Bug Fixes**
  * Centralized and strengthened confidence/metric range validation.
  * Improved embedding result saving behavior for ESM2.
* **Tests**
  * Added unit tests and new mock fixtures for the new embedding and folding oracles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->