### PR TITLE
feat: add ESM3 oracle with multi-track decoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.1.15"
+version = "0.1.16"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},

--- a/src/bagel/oracles/__init__.py
+++ b/src/bagel/oracles/__init__.py
@@ -1,5 +1,5 @@
 from .base import Oracle, OracleResult, OraclesResultDict
-from .embedding import EmbeddingOracle, ESM2, ESM2Result
+from .embedding import EmbeddingOracle, ESM2, ESM2Result, ESM3, ESM3Result
 from .folding import FoldingOracle, ESMFold, ESMFoldResult
 
 __all__ = [
@@ -8,6 +8,8 @@ __all__ = [
     'OraclesResultDict',
     'ESM2',
     'ESM2Result',
+    'ESM3',
+    'ESM3Result',
     'ESMFold',
     'ESMFoldResult',
     'EmbeddingOracle',

--- a/src/bagel/oracles/embedding/__init__.py
+++ b/src/bagel/oracles/embedding/__init__.py
@@ -1,5 +1,6 @@
 from .base import EmbeddingOracle, EmbeddingResult
 from .esm2 import ESM2, ESM2Result
-from .esm3 import ESM3, ESM3Result, ESMC, ESMCResult
+from .esm3 import ESM3, ESM3Result
+from .esmc import ESMC, ESMCResult
 
 __all__ = ['EmbeddingOracle', 'EmbeddingResult', 'ESM2', 'ESM2Result', 'ESM3', 'ESM3Result', 'ESMC', 'ESMCResult']

--- a/src/bagel/oracles/embedding/__init__.py
+++ b/src/bagel/oracles/embedding/__init__.py
@@ -1,4 +1,5 @@
 from .base import EmbeddingOracle, EmbeddingResult
 from .esm2 import ESM2, ESM2Result
+from .esm3 import ESM3, ESM3Result
 
-__all__ = ['EmbeddingOracle', 'EmbeddingResult', 'ESM2', 'ESM2Result']
+__all__ = ['EmbeddingOracle', 'EmbeddingResult', 'ESM2', 'ESM2Result', 'ESM3', 'ESM3Result']

--- a/src/bagel/oracles/embedding/esm3.py
+++ b/src/bagel/oracles/embedding/esm3.py
@@ -73,7 +73,7 @@ def decode_sasa(sasa_logits: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]
     return probabilities @ _SASA_BIN_MIDPOINTS
 
 
-def decode_secondary_structure(ss_logits: npt.NDArray[np.float64]) -> Any:
+def decode_secondary_structure(ss_logits: npt.NDArray[np.float64]) -> str | npt.NDArray[np.str_]:
     """Decode SS8 logits to per-residue secondary-structure letters (argmax).
 
     Uses the last ``len(_SS8_VOCAB)`` classes (``GHITEBSC``). For a single sequence
@@ -103,9 +103,8 @@ class ESM3Result(EmbeddingResult):
     function_logits: npt.NDArray[np.float64] | None = None
     residue_annotation_logits: npt.NDArray[np.float64] | None = None
 
-    @classmethod
-    def save_attributes(cls, filepath: pl.Path) -> None:
-        np.savetxt(filepath.with_suffix('.embeddings'), cls.embeddings, fmt='%.6f', header='embeddings')
+    def save_attributes(self, filepath: pl.Path) -> None:
+        np.savetxt(filepath.with_suffix('.embeddings'), self.embeddings, fmt='%.6f', header='embeddings')
 
 
 class ESM3(EmbeddingOracle):
@@ -174,7 +173,7 @@ class ESM3(EmbeddingOracle):
         return self._post_process(output)
 
     def _post_process(self, output: 'ESM3Output') -> ESM3Result:
-        embeddings = output.embeddings[0, :, :]
+        embeddings = np.asarray(output.embeddings[0, :, :], dtype=np.float64)
         assert len(embeddings.shape) == 2, (
             f'Embeddings is expected to be a 2D tensor, not shape: {embeddings.shape}. '
             'The ESM3 Oracle does not support batches.'
@@ -184,6 +183,7 @@ class ESM3(EmbeddingOracle):
             field, attribute, decoder = self._TRACKS[track]
             logits = getattr(output, field, None)
             if logits is None:
+                logger.warning('ESM3 track %r requested but %s not found in output; leaving as None', track, field)
                 continue
             per_residue = np.asarray(logits)[0]  # drop batch -> (residues, vocab)
             if decoder == 'sasa':

--- a/src/bagel/oracles/embedding/esm3.py
+++ b/src/bagel/oracles/embedding/esm3.py
@@ -1,0 +1,195 @@
+"""
+ESM3 oracle for multi-track predictions via boileroom's ESM3 wrapper.
+
+ESM3 is an all-to-all masked model, so beyond sequence embeddings it can predict
+per-residue tracks (SASA, secondary structure, function, residue annotations)
+from sequence alone. This oracle requests those tracks from boileroom and decodes
+the ones with a clean scalar/label interpretation (SASA -> Angstrom^2 expected
+value; secondary structure -> SS8 letters); function/residue-annotation logits are
+surfaced raw (decoding those to labels needs the SDK's large vocabularies).
+
+The boileroom wrapper is imported lazily inside ``_load`` so this module stays
+importable on the pinned boileroom (which predates the ESM3 track outputs); the
+track outputs require boileroom >= the release that ships
+``boileroom.models.esm3`` track logits.
+
+Decoding constants below are copied from EvolutionaryScale's ``esm`` SDK
+(``esm.utils.constants.esm3``); ``esm`` is not a bagel dependency, so they are
+inlined with their provenance rather than imported.
+"""
+
+import pathlib as pl
+import logging
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+from ...chain import Chain
+from .base import EmbeddingResult, EmbeddingOracle
+
+if TYPE_CHECKING:
+    from boileroom.models.esm3.types import ESM3Output  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+# --- Decoding constants (from esm.utils.constants.esm3) -----------------------
+# SASA discretization boundaries used by the SDK's SASADiscretizingTokenizer. The
+# bins are [0, b0], [b0, b1], ..., [b_last, 2*b_last]; a residue's SASA logits are a
+# distribution over these bins (after the tokenizer's special tokens).
+_SASA_BOUNDARIES = [0.8, 4.0, 9.6, 16.4, 24.5, 32.9, 42.0, 51.5, 61.2, 70.9, 81.6, 93.3, 107.2, 125.4, 151.4]
+_SASA_BIN_EDGES = np.array([0.0, *_SASA_BOUNDARIES, _SASA_BOUNDARIES[-1] * 2.0], dtype=np.float64)
+# Representative Angstrom^2 value per bin (bin midpoints); length 16.
+_SASA_BIN_MIDPOINTS = (_SASA_BIN_EDGES[:-1] + _SASA_BIN_EDGES[1:]) / 2.0
+# SS8 alphabet (esm SSE_8CLASS_VOCAB); the SDK head's non-special classes, in order.
+_SS8_VOCAB = 'GHITEBSC'
+
+
+def _softmax(logits: npt.NDArray[np.float64], axis: int = -1) -> npt.NDArray[np.float64]:
+    shifted = logits - np.max(logits, axis=axis, keepdims=True)
+    exp = np.exp(shifted)
+    return exp / np.sum(exp, axis=axis, keepdims=True)
+
+
+def decode_sasa(sasa_logits: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Decode SASA logits to per-residue SASA (Angstrom^2) as an expected value.
+
+    Parameters
+    ----------
+    sasa_logits : ndarray
+        ``(..., residues, vocab)`` logits over the SASA token vocabulary. Only the
+        trailing ``len(_SASA_BIN_MIDPOINTS)`` bin logits are used (leading special
+        tokens, if present, are ignored).
+
+    Returns
+    -------
+    ndarray
+        ``(..., residues)`` expected SASA in Angstrom^2: ``softmax(bins) . midpoints``.
+    """
+    n_bins = _SASA_BIN_MIDPOINTS.shape[0]
+    bin_logits = np.asarray(sasa_logits, dtype=np.float64)[..., -n_bins:]
+    probabilities = _softmax(bin_logits, axis=-1)
+    return probabilities @ _SASA_BIN_MIDPOINTS
+
+
+def decode_secondary_structure(ss_logits: npt.NDArray[np.float64]) -> Any:
+    """Decode SS8 logits to per-residue secondary-structure letters (argmax).
+
+    Uses the last ``len(_SS8_VOCAB)`` classes (``GHITEBSC``). For a single sequence
+    (2D ``(residues, vocab)`` input) returns an SS8 string; for batched input returns
+    an array of single-character labels.
+    """
+    n_classes = len(_SS8_VOCAB)
+    indices = np.argmax(np.asarray(ss_logits, dtype=np.float64)[..., -n_classes:], axis=-1)
+    letters = np.array(list(_SS8_VOCAB))[indices]
+    if letters.ndim == 1:
+        return ''.join(letters.tolist())
+    return letters
+
+
+class ESM3Result(EmbeddingResult):
+    """Embedding + decoded multi-track results from ESM3.
+
+    ``sasa`` (Angstrom^2) and ``secondary_structure`` (SS8 string) are decoded;
+    ``function_logits`` and ``residue_annotation_logits`` are raw per-residue logits.
+    All track fields are ``None`` unless the corresponding track was requested.
+    """
+
+    input_chains: list[Chain]
+    embeddings: npt.NDArray[np.float64]
+    sasa: npt.NDArray[np.float64] | None = None
+    secondary_structure: str | None = None
+    function_logits: npt.NDArray[np.float64] | None = None
+    residue_annotation_logits: npt.NDArray[np.float64] | None = None
+
+    @classmethod
+    def save_attributes(cls, filepath: pl.Path) -> None:
+        np.savetxt(filepath.with_suffix('.embeddings'), cls.embeddings, fmt='%.6f', header='embeddings')
+
+
+class ESM3(EmbeddingOracle):
+    """Oracle that uses ESM3 to compute embeddings and per-residue track predictions.
+
+    Parameters
+    ----------
+    use_modal : bool
+        Whether to run the boileroom wrapper via Modal (otherwise Apptainer).
+    config : dict
+        Configuration forwarded to the boileroom ESM3 wrapper (e.g. ``model_name``).
+    tracks : list[str]
+        Extra tracks to request/decode, any of: ``"sasa"``, ``"secondary_structure"``,
+        ``"function"``, ``"residue_annotations"``. Empty by default (embeddings only).
+        The structure/folding track is not available through this oracle.
+    """
+
+    result_class = ESM3Result
+
+    # bagel track name -> (boileroom include_fields key, result attribute, decoder tag)
+    _TRACKS: dict[str, tuple[str, str, str | None]] = {
+        'sasa': ('sasa_logits', 'sasa', 'sasa'),
+        'secondary_structure': ('secondary_structure_logits', 'secondary_structure', 'ss'),
+        'function': ('function_logits', 'function_logits', None),
+        'residue_annotations': ('residue_annotation_logits', 'residue_annotation_logits', None),
+    }
+
+    def __init__(
+        self,
+        use_modal: bool = False,
+        config: dict[str, Any] | None = None,
+        tracks: list[str] | None = None,
+    ) -> None:
+        if config is None:
+            config = {}
+        self.use_modal = use_modal
+        self.tracks = list(tracks or [])
+        unknown = [track for track in self.tracks if track not in self._TRACKS]
+        if unknown:
+            raise ValueError(f'Unknown ESM3 tracks: {unknown}. Valid tracks: {sorted(self._TRACKS)}')
+        self.default_config: dict[str, Any] = {'model_name': 'esm3_sm_open_v1'}
+        self._load(config)
+
+    def _load(self, config: dict[str, Any] | None = None) -> None:
+        # Lazy import: keeps this module importable without the boileroom ESM3
+        # wrapper present, and lets tests patch _load out.
+        from boileroom.models.esm3.esm3 import ESM3 as ESM3Boiler  # type: ignore
+
+        if config is None:
+            config = {}
+        merged_config = {**self.default_config, **config}
+        backend = 'modal' if self.use_modal else 'apptainer'
+        self.model = ESM3Boiler(backend=backend, config=merged_config)
+
+    def _pre_process(self, chains: list[Chain]) -> list[str]:
+        """Join chains with ':' for multimers (encoded jointly by ESM3)."""
+        monomers = [chain.sequence for chain in chains]
+        return [':'.join(monomers)]
+
+    def embed(self, chains: list[Chain]) -> ESM3Result:
+        """Compute ESM3 embeddings and any requested/decoded tracks for the chains."""
+        self.input_chains = chains
+        include_fields = [self._TRACKS[track][0] for track in self.tracks]
+        options = {'include_fields': include_fields} if include_fields else None
+        output = self.model.embed(self._pre_process(chains), options=options)
+        return self._post_process(output)
+
+    def _post_process(self, output: 'ESM3Output') -> ESM3Result:
+        embeddings = output.embeddings[0, :, :]
+        assert len(embeddings.shape) == 2, (
+            f'Embeddings is expected to be a 2D tensor, not shape: {embeddings.shape}. '
+            'The ESM3 Oracle does not support batches.'
+        )
+        result_kwargs: dict[str, Any] = {'input_chains': self.input_chains, 'embeddings': embeddings}
+        for track in self.tracks:
+            field, attribute, decoder = self._TRACKS[track]
+            logits = getattr(output, field, None)
+            if logits is None:
+                continue
+            per_residue = np.asarray(logits)[0]  # drop batch -> (residues, vocab)
+            if decoder == 'sasa':
+                result_kwargs['sasa'] = decode_sasa(per_residue)
+            elif decoder == 'ss':
+                result_kwargs['secondary_structure'] = decode_secondary_structure(per_residue)
+            else:
+                result_kwargs[attribute] = per_residue
+        return self.result_class(**result_kwargs)

--- a/tests/unit_tests/test_esm3_oracle.py
+++ b/tests/unit_tests/test_esm3_oracle.py
@@ -115,3 +115,4 @@ class TestESM3Oracle:
         assert np.allclose(result.sasa, [_SASA_BIN_MIDPOINTS[2], _SASA_BIN_MIDPOINTS[7]])
         assert result.secondary_structure == 'HE'
         assert result.function_logits is None
+        assert result.residue_annotation_logits is None

--- a/tests/unit_tests/test_esm3_oracle.py
+++ b/tests/unit_tests/test_esm3_oracle.py
@@ -1,0 +1,117 @@
+"""Unit tests for the ESM3 oracle and its track decoders."""
+
+import numpy as np
+import pytest
+
+import bagel as bg
+from bagel.oracles.embedding.esm3 import (
+    ESM3,
+    ESM3Result,
+    _SASA_BIN_MIDPOINTS,
+    _SS8_VOCAB,
+    decode_sasa,
+    decode_secondary_structure,
+)
+
+
+class TestDecodeSasa:
+    def test_onehot_bins_return_bin_midpoints(self):
+        n_bins = _SASA_BIN_MIDPOINTS.shape[0]
+        logits = np.zeros((2, n_bins))
+        logits[0, 3] = 1e3
+        logits[1, 0] = 1e3
+        sasa = decode_sasa(logits)
+        assert sasa.shape == (2,)
+        assert np.isclose(sasa[0], _SASA_BIN_MIDPOINTS[3])
+        assert np.isclose(sasa[1], _SASA_BIN_MIDPOINTS[0])
+
+    def test_uniform_logits_give_mean_of_midpoints(self):
+        logits = np.zeros((1, _SASA_BIN_MIDPOINTS.shape[0]))
+        assert np.isclose(decode_sasa(logits)[0], _SASA_BIN_MIDPOINTS.mean())
+
+    def test_leading_special_tokens_are_ignored(self):
+        n_bins = _SASA_BIN_MIDPOINTS.shape[0]
+        bins = np.zeros((1, n_bins))
+        bins[0, 5] = 1e3
+        with_specials = np.concatenate([np.full((1, 3), 1e6), bins], axis=1)  # 3 specials + 16 bins
+        assert np.isclose(decode_sasa(with_specials)[0], _SASA_BIN_MIDPOINTS[5])
+
+
+class TestDecodeSecondaryStructure:
+    def test_argmax_returns_ss8_string(self):
+        n = len(_SS8_VOCAB)
+        logits = np.zeros((2, n))
+        logits[0, _SS8_VOCAB.index('H')] = 10
+        logits[1, _SS8_VOCAB.index('C')] = 10
+        assert decode_secondary_structure(logits) == 'HC'
+
+    def test_leading_special_tokens_are_ignored(self):
+        n = len(_SS8_VOCAB)
+        logits = np.zeros((1, n))
+        logits[0, _SS8_VOCAB.index('E')] = 10
+        with_specials = np.concatenate([np.full((1, 3), 99), logits], axis=1)
+        assert decode_secondary_structure(with_specials) == 'E'
+
+
+class TestESM3Result:
+    def test_stores_decoded_and_raw_tracks(self):
+        chains = [bg.Chain([bg.Residue(name='A', chain_ID='A', index=0)])]
+        result = ESM3Result(
+            input_chains=chains,
+            embeddings=np.zeros((3, 8)),
+            sasa=np.array([1.0, 2.0, 3.0]),
+            secondary_structure='HEC',
+        )
+        assert result.sasa.tolist() == [1.0, 2.0, 3.0]
+        assert result.secondary_structure == 'HEC'
+        assert result.function_logits is None
+        assert result.residue_annotation_logits is None
+
+
+class TestESM3Oracle:
+    def test_result_class(self):
+        assert ESM3.result_class is ESM3Result
+
+    def test_pre_process_monomer(self, monkeypatch):
+        monkeypatch.setattr(ESM3, '_load', lambda self, config=None: None)
+        oracle = ESM3(tracks=['sasa'])
+        chains = [bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])]
+        assert oracle._pre_process(chains) == ['AAA']
+
+    def test_pre_process_multimer(self, monkeypatch):
+        monkeypatch.setattr(ESM3, '_load', lambda self, config=None: None)
+        oracle = ESM3(tracks=['sasa'])
+        chain_a = bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(3)])
+        chain_b = bg.Chain([bg.Residue(name='G', chain_ID='B', index=i) for i in range(2)])
+        assert oracle._pre_process([chain_a, chain_b]) == ['AAA:GG']
+
+    def test_unknown_track_raises(self, monkeypatch):
+        monkeypatch.setattr(ESM3, '_load', lambda self, config=None: None)
+        with pytest.raises(ValueError, match='Unknown ESM3 tracks'):
+            ESM3(tracks=['nope'])
+
+    def test_post_process_decodes_requested_tracks(self, monkeypatch):
+        monkeypatch.setattr(ESM3, '_load', lambda self, config=None: None)
+        oracle = ESM3(tracks=['sasa', 'secondary_structure'])
+        oracle.input_chains = [bg.Chain([bg.Residue(name='A', chain_ID='A', index=i) for i in range(2)])]
+
+        n_sasa = _SASA_BIN_MIDPOINTS.shape[0]
+        sasa_logits = np.zeros((1, 2, n_sasa))
+        sasa_logits[0, 0, 2] = 1e3  # residue 0 -> bin 2
+        sasa_logits[0, 1, 7] = 1e3  # residue 1 -> bin 7
+        ss_logits = np.zeros((1, 2, len(_SS8_VOCAB)))
+        ss_logits[0, 0, _SS8_VOCAB.index('H')] = 10
+        ss_logits[0, 1, _SS8_VOCAB.index('E')] = 10
+
+        class _Output:
+            embeddings = np.zeros((1, 2, 8))
+
+        output = _Output()
+        output.sasa_logits = sasa_logits
+        output.secondary_structure_logits = ss_logits
+
+        result = oracle._post_process(output)
+        assert result.embeddings.shape == (2, 8)
+        assert np.allclose(result.sasa, [_SASA_BIN_MIDPOINTS[2], _SASA_BIN_MIDPOINTS[7]])
+        assert result.secondary_structure == 'HE'
+        assert result.function_logits is None


### PR DESCRIPTION
## Summary
Adds a bagel **ESM3 oracle** that exposes ESM3's per-residue tracks (beyond embeddings) and decodes the ones with a clean interpretation. ESM3 is an all-to-all masked model, so these are predicted from sequence alone.

## Decoding
- **`sasa`** → per-residue SASA in Å², as the **expected value** over the SDK's discretized SASA bins: `softmax(bin logits) · bin_midpoints`.
- **`secondary_structure`** → SS8 string via argmax over the 8 classes (`GHITEBSC`).
- **`function` / `residue_annotations`** → raw per-residue logits (decoding to labels needs the SDK's large vocabularies; left as a follow-up).

## Usage
```python
oracle = bg.oracles.embedding.ESM3(tracks=["sasa", "secondary_structure"])
result = oracle.embed(chains)
result.sasa                 # (residues,) Å²
result.secondary_structure  # e.g. "HHHEEECC…"
```

## Details
- `ESM3` takes a `tracks` list; `embed()` requests the matching boileroom `include_fields`, and `ESM3Result` carries decoded/raw outputs.
- Decoding constants (SASA boundaries, SS8 alphabet) are inlined from `esm.utils.constants.esm3` **with provenance**, since `esm` is not a bagel dependency.
- boileroom import is **lazy** (module stays importable on the pinned boileroom).
- Unit tests cover the pure decoders (bin midpoints, argmax, special-token handling), the result type, track validation, pre-processing, and end-to-end `_post_process`. Full bagel unit suite green (111 passed).

## Blocked on
Requires a boileroom release exposing ESM3 track logits (`boileroom.models.esm3`) — see boileroom PR `feat/esm3-sasa-output`. **Draft until that lands and bagel's boileroom pin is bumped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new embedding option with decoded sequence-level outputs, including secondary structure and SASA predictions.
  * Exposed the new embedding capability through the public API.

* **Tests**
  * Added unit coverage for decoding behavior, track handling, and result formatting.

* **Chores**
  * Bumped the package version to `0.1.16`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->