### PR TITLE
feat: add sae-feature-annotations skill

### DIFF
--- a/.claude/skills/sae-feature-annotations/SKILL.md
+++ b/.claude/skills/sae-feature-annotations/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: sae-feature-annotations
+description: >-
+  Look up what a Biohub ESM-C sparse-autoencoder (SAE) feature *means* — its label,
+  description, top-activating proteins, decoder neighbours, and activation statistics —
+  by querying the Biohub feature-annotation API, with a local lookup table as an offline
+  fallback. Use this whenever the user has SAE feature indices (e.g. from `boileroom`'s
+  `SAE` model / `pooled_features`) and wants to interpret them: "what is SAE feature
+  12345", "which features fired on my protein and what do they correspond to", "annotate
+  these feature indices", "what proteins most activate this feature", "find the
+  zinc-binding SAE feature", "decoder nearest neighbours of feature N", or any request to
+  turn ESM-C SAE feature numbers into biology. Also trigger when the user mentions Biohub
+  feature annotations, the feature viewer, or the ESMC-6B layer-60 SAE codebook. These
+  annotations are only valid for the `ESMC-6B-sae-layer60-k64-codebook16384` SAE — the
+  skill says so up front and refuses to pretend otherwise.
+---
+
+# Annotating ESM-C SAE features from Biohub
+
+This skill turns **SAE feature indices into biology**. A sparse autoencoder trained on
+ESM-C representations decomposes each residue into a sparse set of interpretable features
+(directions in a codebook). Biohub publishes an annotation for each feature — a human
+label, top-activating proteins, decoder neighbours, activation stats — and this skill
+fetches and presents them, with a bundled offline table as a fallback.
+
+## The one thing to say first, every time
+
+**These annotations are only valid for the SAE `ESMC-6B-sae-layer60-k64-codebook16384`**
+— ESM-C 6B, transformer layer 60, TopK k=64, codebook of 2**14 = 16384 features. This is
+the SAE from *Language Modeling Materializes a World Model of Protein Biology* (Biohub,
+2026), and the default Forge SAE that `boileroom`'s `SAE` model uses.
+
+A `feature_index` means something completely different under any other layer, k, or
+codebook. So before interpreting anything, **confirm the user produced their features with
+this exact SAE** (in `boileroom` that is the default `feature_source="forge"` path, i.e.
+`forge_sae_model = "esmc-6b-2024-12-sae-layer60-k64-codebook16384"`). If they used a local
+300M/600M SAE or a different layer, tell them these labels do not apply and stop — do not
+hand them annotations that describe a different feature basis.
+
+Lead with this. Do not bury it under the results.
+
+## Two sources, and which to trust
+
+Biohub is authoritative. **Always query it first** when an API key is available; only fall
+back to the local table when you can't reach Biohub, and say so.
+
+| Source | What it gives | When |
+| --- | --- | --- |
+| **Biohub (live)** | Everything. The full map *and* per-feature detail. | Preferred, always try first. Needs an API key. |
+| **Local table** (`assets/feature_annotations.json`) | Only the basic map: `feature_index -> label + short description`. | Fallback when there's no key or no network. Warn that it may have drifted. |
+
+When you fall back to the local table, **remind the user it is a point-in-time snapshot and
+may have diverged from Biohub** if the annotations were updated since it was last
+refreshed — and that the extended detail below is simply not available offline. The script
+prints this reminder automatically; reinforce it in your summary.
+
+## Two endpoints = two levels of detail
+
+1. **The whole map, in one call** — `GET /esm/protein/api/v1alpha1/features` returns every
+   feature's `feature_index`, `label`, and short `description` at once. This is the
+   `feature -> annotation` map. It is small, so it is the thing cached locally for offline
+   use (`refresh` snapshots it).
+
+2. **One feature, in full** — `GET /esm/protein/api/v1alpha1/features/{feature_index}`
+   returns the longform description, **top-activating UniRef90 and SwissProt proteins**,
+   **decoder nearest-neighbour features**, and **activation statistics**. This is only
+   available **live** — there is no offline substitute. Any request that wants proteins,
+   neighbours, or stats *requires* the live call and thus an API key.
+
+See `references/api.md` for the exact request/response shapes, base URL, and auth details.
+
+## The tool
+
+Everything goes through one stdlib-only script (no dependencies to install):
+
+```
+scripts/sae_features.py
+  refresh                 # fetch the full map from Biohub and (re)write the offline table
+  list   [--limit N]      # list features (live if a key is set, else cache)
+  search <text>           # find features whose label/description matches <text>
+  get    <feature_index>  # full detail for one feature (LIVE ONLY, needs a key)
+  # shared flags: --base-url, --token, --cache, --sae-model, --json
+```
+
+Auth resolves from `--token`, then `ESM_API_KEY`, then `FORGE_TOKEN` (the same key
+`boileroom`'s Forge backend uses). Base URL defaults to `https://biohub.ai`
+(`--base-url` / `BIOHUB_BASE_URL` to override).
+
+## Workflow
+
+1. **State the validity constraint** (the section above) and confirm the user's features
+   came from `ESMC-6B-sae-layer60-k64-codebook16384`. If not, stop and explain why the
+   labels don't apply.
+
+2. **Figure out what they need**, because it decides whether a key is required:
+   - Just labels / short descriptions for some indices, or a keyword search →
+     `list` / `search`. Works offline against the cached table if needed.
+   - Top-activating proteins, decoder neighbours, or activation stats for a feature →
+     `get`. **Live only** — a key is mandatory.
+
+3. **Get the API key.** Prefer the user's own key via `ESM_API_KEY` (or `--token`). Never
+   ask them to paste a secret into the chat if an env var will do; never store it. If they
+   have no key and only want basic labels, proceed against the cache.
+
+4. **Query live first.** Run the relevant subcommand with the key. If Biohub is
+   unreachable, the script falls back to the cache for `list`/`search` and prints a
+   divergence warning — surface that to the user. `get` cannot fall back; if it fails,
+   report the error rather than substituting anything.
+
+5. **Seed the cache when appropriate.** If the offline table is empty (never seeded) or
+   stale and the user has a key, run `refresh` so future offline lookups work. This writes
+   `assets/feature_annotations.json` — mention that you updated it.
+
+6. **Present results plainly.** Give the label and description for each index; for `get`,
+   summarize the top proteins, nearest-neighbour features, and activation stats. Keep the
+   feature index next to every annotation so the mapping is unambiguous.
+
+## Notes
+
+- The offline table may ship **unseeded** (empty `features`) if it was never refreshed with
+  a key. In that case `list`/`search` will tell you to run `refresh`. That is expected —
+  don't invent labels; get a key and refresh, or query live.
+- If Biohub rejects the bearer token or the endpoint shape differs from
+  `references/api.md`, the auth/parse logic lives in one place (`_http_get_json` /
+  `_live_feature_map` in the script) — adjust there. The defaults follow the Forge SDK
+  convention (`Authorization: Bearer <token>`, base `https://biohub.ai`).
+- This skill only *reads* annotations. Producing the SAE features themselves (running
+  ESM-C + the SAE to get `feature_index` values for a sequence) is `boileroom`'s `SAE`
+  model, on the `features/sae` branch — a different tool.

--- a/.claude/skills/sae-feature-annotations/assets/feature_annotations.json
+++ b/.claude/skills/sae-feature-annotations/assets/feature_annotations.json
@@ -1,0 +1,8 @@
+{
+  "sae_model": "esmc-6b-2024-12-sae-layer60-k64-codebook16384",
+  "base_url": "https://biohub.ai",
+  "endpoint": "https://biohub.ai/esm/protein/api/v1alpha1/features",
+  "fetched_at": null,
+  "note": "OFFLINE FALLBACK TABLE (feature_index -> label + short description) for the ESMC-6B-sae-layer60-k64-codebook16384 SAE. Not yet seeded. Run `python ../scripts/sae_features.py refresh` with a valid API key (ESM_API_KEY / FORGE_TOKEN) to populate `features` from Biohub. Until then, every query must go live. Once seeded, this table is only a fallback: Biohub is authoritative and may have changed since `fetched_at`.",
+  "features": []
+}

--- a/.claude/skills/sae-feature-annotations/evals/evals.json
+++ b/.claude/skills/sae-feature-annotations/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "sae-feature-annotations",
+  "evals": [
+    {
+      "id": 0,
+      "name": "basic-map-lookup",
+      "prompt": "I ran boileroom's SAE model on one of my proteins and pulled out the SAE feature indices that fired: 42, 100, and 777. What do these features correspond to biologically?",
+      "expected_output": "Leads with the ESMC-6B-sae-layer60-k64-codebook16384 validity note; returns the label+description for features 42/100/777 obtained by querying Biohub; keeps each index next to its annotation.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "extended-detail",
+      "prompt": "For SAE feature 42, I want the full picture - which real proteins activate it most (both UniRef90 and SwissProt), what its decoder nearest-neighbour features are, and its activation statistics.",
+      "expected_output": "Recognizes this needs the per-feature detail endpoint (live only, key required), calls it, and summarizes top UniRef90+SwissProt proteins, decoder nearest neighbours, and activation statistics for feature 42. Leads with the validity note.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "wrong-sae-guardrail",
+      "prompt": "I used a local ESM-C 600M sparse autoencoder at layer 27 (codebook 16384) and got feature index 88 firing strongly on my sequence. What does feature 88 correspond to? Look it up in the Biohub annotations.",
+      "expected_output": "Refuses to map feature 88 to a Biohub label because the Biohub annotations are only valid for ESMC-6B layer 60 (k64, codebook16384), not a 600M layer-27 SAE. Explains the feature basis differs; does not fabricate an annotation.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/sae-feature-annotations/references/api.md
+++ b/.claude/skills/sae-feature-annotations/references/api.md
@@ -1,0 +1,68 @@
+# Biohub SAE feature annotation API
+
+Reference for the two endpoints the skill uses. These annotations come from the
+sparse-autoencoder analysis in *Language Modeling Materializes a World Model of
+Protein Biology* (Biohub, 2026) and describe exactly one SAE:
+
+> **ESMC-6B-sae-layer60-k64-codebook16384** — ESM-C 6B, transformer layer 60,
+> TopK with k=64, codebook of 2**14 = 16384 features.
+
+A `feature_index` (0…16383) is only meaningful under this SAE. The same index
+under a different layer / k / codebook is an unrelated direction, so never reuse
+these labels for another SAE. This is the SAE the `boileroom` `SAE` model uses by
+default via its Forge backend (`forge_sae_model =
+esmc-6b-2024-12-sae-layer60-k64-codebook16384`, `forge_url = https://biohub.ai`).
+
+## Base URL and auth
+
+- **Base URL:** `https://biohub.ai` (same host as `boileroom`'s `forge_url`).
+  Override with `--base-url` or `BIOHUB_BASE_URL`.
+- **Auth:** an API key, the same credential `ESMCForgeInferenceClient` uses. The
+  script reads `--token`, then `ESM_API_KEY`, then `FORGE_TOKEN`, and sends it as
+  `Authorization: Bearer <token>`.
+- If Biohub actually expects a different header name/scheme than bearer, adjust
+  `_http_get_json` in `scripts/sae_features.py` — it is the single place auth is
+  applied. (The exact header could not be verified from the build environment,
+  which blocks `biohub.ai`; the bearer default matches the Forge SDK convention.)
+
+## Endpoint 1 — the feature map (all features at once)
+
+```
+GET {base}/esm/protein/api/v1alpha1/features
+```
+
+Returns every SAE feature's `feature_index`, `label`, and short `description` in a
+single call. This is the whole `feature -> annotation` map, small enough to cache.
+`refresh` snapshots it to `assets/feature_annotations.json` so `list` / `search`
+work offline as a fallback.
+
+Expected item shape (the script is liberal about the envelope — a bare list or
+`{"features": [...]}` / `{"data": [...]}` are all accepted):
+
+```json
+{ "feature_index": 12345, "label": "zinc-binding site", "description": "short description" }
+```
+
+## Endpoint 2 — one feature's full detail (live only)
+
+```
+GET {base}/esm/protein/api/v1alpha1/features/{feature_index}
+```
+
+Returns the extended record for a single feature:
+
+- longform description,
+- top-activating **UniRef90** and **SwissProt** proteins,
+- decoder **nearest-neighbour** features,
+- **activation statistics**.
+
+There is no offline substitute for this — it is always a live call and needs an
+API key. The skill only falls back to the cached table for the basic
+label/description map (endpoint 1), never for this detail.
+
+## Divergence
+
+The cached table is a point-in-time snapshot stamped with `fetched_at`. When the
+script falls back to it (no key or Biohub unreachable) it prints a reminder that
+Biohub is authoritative and may have changed since. Re-run `refresh` with a key to
+bring the cache back in sync.

--- a/.claude/skills/sae-feature-annotations/references/api.md
+++ b/.claude/skills/sae-feature-annotations/references/api.md
@@ -60,6 +60,24 @@ There is no offline substitute for this — it is always a live call and needs a
 API key. The skill only falls back to the cached table for the basic
 label/description map (endpoint 1), never for this detail.
 
+### How to read "decoder nearest neighbours"
+
+Each SAE feature owns a **decoder vector** — a direction in ESM-C's
+representation space that the feature writes back when it is active. The decoder
+nearest neighbours are the other features whose decoder vectors are closest to
+this one by **cosine similarity** (e.g. neighbour `512` at `0.91` points almost
+the same way). Because nearby directions tend to encode nearby biology,
+neighbours are usually semantically related features — helpful for interpreting a
+vaguely-labelled feature, and for spotting **feature splitting**, where one real
+concept is spread across several nearly-parallel features (a common SAE artifact).
+
+This is a property of the learned dictionary's geometry, **not** co-activation:
+two features can have near-parallel decoder directions yet rarely fire on the same
+residues. For "which proteins light this feature up," use the top-activating
+proteins and activation statistics instead. Like everything here, neighbour
+relationships are specific to `ESMC-6B-sae-layer60-k64-codebook16384` and do not
+carry over to another SAE.
+
 ## Divergence
 
 The cached table is a point-in-time snapshot stamped with `fetched_at`. When the

--- a/.claude/skills/sae-feature-annotations/scripts/sae_features.py
+++ b/.claude/skills/sae-feature-annotations/scripts/sae_features.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Part of the `sae-feature-annotations` Claude skill.
+# Queries Biohub for annotations of ESM-C sparse-autoencoder (SAE) features and
+# maintains a local fallback lookup table. Standard library only (urllib) so it
+# runs anywhere without installing dependencies.
+#
+# IMPORTANT: the annotations returned here are only meaningful for the SAE
+# ESMC-6B-sae-layer60-k64-codebook16384 (ESM-C 6B, layer 60, k=64, codebook
+# 16384). A feature_index means something completely different under any other
+# layer / k / codebook, so never mix these annotations with a different SAE.
+# -----------------------------------------------------------------------------
+"""Look up SAE feature annotations from Biohub, with an offline fallback table.
+
+Two data sources, mirroring the two Biohub endpoints:
+
+  * The **map** (feature_index -> label + short description) for *every* feature,
+    from ``GET {base}/esm/protein/api/v1alpha1/features``. This is small enough to
+    cache locally, so ``refresh`` snapshots it to a JSON file that ``list`` /
+    ``search`` / ``get`` can fall back to when no API key or network is available.
+  * The **detail** for a single feature (longform description, top-activating
+    UniRef90 & SwissProt proteins, decoder nearest neighbours, activation
+    statistics), from ``GET {base}/esm/protein/api/v1alpha1/features/{index}``.
+    This is only available live — there is no offline substitute.
+
+Policy: always try Biohub first (it is authoritative), and only fall back to the
+cached table when the live call cannot be made — printing a clear reminder that
+the cache may have drifted from Biohub since it was last refreshed.
+
+Subcommands
+-----------
+  refresh                 Fetch the full feature map from Biohub and write the cache.
+  list                    List features (live if possible, else cache).
+  search <text>           Search labels/descriptions for <text> (live or cache).
+  get <feature_index>     Full detail for one feature (live only).
+
+Configuration (flags override environment override defaults)
+------------------------------------------------------------
+  --base-url   BIOHUB_BASE_URL      default https://biohub.ai
+  --token      ESM_API_KEY / FORGE_TOKEN
+  --cache      SAE_FEATURE_CACHE    default <skill>/assets/feature_annotations.json
+  --sae-model  SAE_MODEL            default esmc-6b-2024-12-sae-layer60-k64-codebook16384
+
+Examples
+--------
+  python sae_features.py refresh                 # seed/refresh the offline table (needs key)
+  python sae_features.py search "zinc binding"   # find features by keyword
+  python sae_features.py get 12345 --json        # full detail for feature 12345
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# The one SAE these annotations describe. Everything here is meaningless for any
+# other layer / k / codebook, so we carry it around and stamp it into the cache.
+DEFAULT_SAE_MODEL = "esmc-6b-2024-12-sae-layer60-k64-codebook16384"
+DEFAULT_BASE_URL = "https://biohub.ai"
+API_PREFIX = "/esm/protein/api/v1alpha1"
+
+# assets/feature_annotations.json sits next to this scripts/ directory.
+DEFAULT_CACHE = Path(__file__).resolve().parent.parent / "assets" / "feature_annotations.json"
+
+VALIDITY_BANNER = (
+    "These SAE feature annotations are only valid for "
+    "ESMC-6B-sae-layer60-k64-codebook16384 (ESM-C 6B, layer 60, k=64, "
+    "codebook 16384). They do not transfer to any other SAE."
+)
+
+
+def _eprint(*args: object) -> None:
+    """Print to stderr so machine-readable stdout (``--json``) stays clean."""
+    print(*args, file=sys.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP
+# --------------------------------------------------------------------------- #
+def _resolve_token(explicit: str | None) -> str | None:
+    return explicit or os.environ.get("ESM_API_KEY") or os.environ.get("FORGE_TOKEN")
+
+
+def _http_get_json(url: str, token: str | None, timeout: int = 60) -> object:
+    """GET a URL and parse JSON. Raises on HTTP/network/JSON errors.
+
+    Auth defaults to a bearer token (the same credential ``ESMCForgeInferenceClient``
+    uses). If Biohub expects a different header, adjust it here and in the skill's
+    references/api.md.
+    """
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 (trusted host)
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _features_url(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}{API_PREFIX}/features"
+
+
+def _feature_detail_url(base_url: str, feature_index: int) -> str:
+    return f"{base_url.rstrip('/')}{API_PREFIX}/features/{feature_index}"
+
+
+# --------------------------------------------------------------------------- #
+# Cache
+# --------------------------------------------------------------------------- #
+def _load_cache(cache_path: Path) -> dict | None:
+    if not cache_path.exists():
+        return None
+    try:
+        data = json.loads(cache_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        _eprint(f"[warn] could not read cache {cache_path}: {exc}")
+        return None
+    # A never-seeded placeholder has an empty feature list; treat as no cache.
+    if not data.get("features"):
+        return None
+    return data
+
+
+def _cache_features(cache: dict) -> list[dict]:
+    return cache.get("features", [])
+
+
+def _live_feature_map(base_url: str, token: str | None) -> list[dict]:
+    """Fetch the full feature map. Normalizes to a list of dicts with at least
+    ``feature_index``, ``label``, ``description``."""
+    payload = _http_get_json(_features_url(base_url), token)
+    # Be liberal about the envelope: accept a bare list or {"features": [...]}.
+    if isinstance(payload, dict):
+        payload = payload.get("features", payload.get("data", []))
+    if not isinstance(payload, list):
+        raise ValueError(f"Unexpected features payload shape: {type(payload).__name__}")
+    return payload
+
+
+def _get_map(args: argparse.Namespace) -> tuple[list[dict], str]:
+    """Return (features, source) where source is 'live' or 'cache'.
+
+    Live first (authoritative); fall back to the cache with a loud divergence
+    reminder when the live call cannot be made.
+    """
+    token = _resolve_token(args.token)
+    if token:
+        try:
+            return _live_feature_map(args.base_url, token), "live"
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError) as exc:
+            _eprint(f"[warn] Biohub live query failed ({exc}); falling back to local cache.")
+    else:
+        _eprint("[warn] no API key (ESM_API_KEY / FORGE_TOKEN / --token); using local cache.")
+
+    cache = _load_cache(args.cache)
+    if cache is None:
+        _eprint(
+            f"[error] no usable cache at {args.cache}. Seed it with a key:\n"
+            f"        python {Path(__file__).name} refresh"
+        )
+        raise SystemExit(2)
+    fetched = cache.get("fetched_at", "unknown time")
+    _eprint(
+        f"[cache] using local table snapshotted at {fetched} for SAE "
+        f"{cache.get('sae_model', '?')}. Biohub may have changed since; refresh "
+        f"with an API key to be sure the labels are current."
+    )
+    return _cache_features(cache), "cache"
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands
+# --------------------------------------------------------------------------- #
+def cmd_refresh(args: argparse.Namespace) -> int:
+    token = _resolve_token(args.token)
+    if not token:
+        _eprint(
+            "[error] refresh needs an API key. Set ESM_API_KEY (or FORGE_TOKEN), "
+            "or pass --token. Get one from your Biohub/Forge account."
+        )
+        return 2
+    _eprint(f"[info] fetching feature map from {_features_url(args.base_url)} ...")
+    try:
+        features = _live_feature_map(args.base_url, token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError) as exc:
+        _eprint(f"[error] refresh failed: {exc}")
+        return 1
+    cache = {
+        "sae_model": args.sae_model,
+        "base_url": args.base_url,
+        "endpoint": _features_url(args.base_url),
+        "fetched_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "note": VALIDITY_BANNER,
+        "features": features,
+    }
+    args.cache.parent.mkdir(parents=True, exist_ok=True)
+    args.cache.write_text(json.dumps(cache, indent=2, sort_keys=False))
+    _eprint(f"[ok] wrote {len(features)} features to {args.cache}")
+    return 0
+
+
+def _match(feature: dict, text: str) -> bool:
+    hay = f"{feature.get('label', '')} {feature.get('description', '')}".lower()
+    return text.lower() in hay
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    features, source = _get_map(args)
+    if getattr(args, "query", None):
+        features = [f for f in features if _match(f, args.query)]
+    features = sorted(features, key=lambda f: f.get("feature_index", 0))
+    if args.limit:
+        features = features[: args.limit]
+    if args.json:
+        print(json.dumps({"source": source, "count": len(features), "features": features}, indent=2))
+    else:
+        _eprint(VALIDITY_BANNER)
+        _eprint(f"[{source}] {len(features)} feature(s):")
+        for f in features:
+            print(f"  {f.get('feature_index'):>6}  {f.get('label', '')}")
+            if f.get("description"):
+                print(f"          {f['description']}")
+    return 0
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    token = _resolve_token(args.token)
+    if not token:
+        _eprint(
+            "[error] Extended feature detail (longform description, top-activating "
+            "UniRef90/SwissProt proteins, decoder nearest neighbours, activation "
+            "statistics) is only available live from Biohub and needs an API key.\n"
+            "        Set ESM_API_KEY / FORGE_TOKEN or pass --token. For just the "
+            "label + short description you can use the offline table:\n"
+            f"        python {Path(__file__).name} search <text>"
+        )
+        return 2
+    url = _feature_detail_url(args.base_url, args.feature_index)
+    _eprint(f"[info] GET {url}")
+    try:
+        detail = _http_get_json(url, token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError) as exc:
+        _eprint(f"[error] could not fetch feature {args.feature_index}: {exc}")
+        return 1
+    if args.json:
+        print(json.dumps(detail, indent=2))
+    else:
+        _eprint(VALIDITY_BANNER)
+        print(json.dumps(detail, indent=2))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    def add_common(sub: argparse.ArgumentParser) -> None:
+        sub.add_argument("--base-url", default=os.environ.get("BIOHUB_BASE_URL", DEFAULT_BASE_URL))
+        sub.add_argument("--token", default=None, help="API key; else ESM_API_KEY / FORGE_TOKEN.")
+        sub.add_argument(
+            "--cache",
+            type=Path,
+            default=Path(os.environ.get("SAE_FEATURE_CACHE", DEFAULT_CACHE)),
+        )
+        sub.add_argument("--sae-model", default=os.environ.get("SAE_MODEL", DEFAULT_SAE_MODEL))
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_refresh = subparsers.add_parser("refresh", help="Fetch full feature map and write the cache (needs key).")
+    add_common(p_refresh)
+    p_refresh.set_defaults(func=cmd_refresh)
+
+    p_list = subparsers.add_parser("list", help="List features (live if possible, else cache).")
+    add_common(p_list)
+    p_list.add_argument("--limit", type=int, default=0, help="Max rows (0 = all).")
+    p_list.add_argument("--json", action="store_true")
+    p_list.set_defaults(func=cmd_list, query=None)
+
+    p_search = subparsers.add_parser("search", help="Search labels/descriptions (live if possible, else cache).")
+    add_common(p_search)
+    p_search.add_argument("query", help="Text to match in label or description.")
+    p_search.add_argument("--limit", type=int, default=0)
+    p_search.add_argument("--json", action="store_true")
+    p_search.set_defaults(func=cmd_list)
+
+    p_get = subparsers.add_parser("get", help="Full detail for one feature (live only, needs key).")
+    add_common(p_get)
+    p_get.add_argument("feature_index", type=int)
+    p_get.add_argument("--json", action="store_true")
+    p_get.set_defaults(func=cmd_get)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds a new Claude skill, **`sae-feature-annotations`**, that turns ESM-C sparse-autoencoder (SAE) feature indices into biology by querying the Biohub feature-annotation API, with a local lookup table as an offline fallback.

The annotations describe exactly one SAE — **`ESMC-6B-sae-layer60-k64-codebook16384`** (ESM-C 6B, layer 60, k=64, codebook 16384), the default Forge SAE used by `boileroom`'s `SAE` model. The skill leads with this validity constraint on every use and refuses to map indices that came from a different SAE.

## How it works

Two data sources, mirroring the two API endpoints:

- **Live Biohub (preferred, needs an API key)** — always queried first, since it is authoritative.
  - `GET /esm/protein/api/v1alpha1/features` → the full `feature_index → label + description` map (small enough to cache).
  - `GET /esm/protein/api/v1alpha1/features/{index}` → per-feature detail: longform description, top-activating UniRef90 & SwissProt proteins, decoder nearest-neighbour features, and activation statistics. **Live only** — no offline substitute.
- **Local lookup table (offline fallback)** — used only when there is no key or Biohub is unreachable, and only for the basic label/description map. Falling back prints a reminder that the snapshot may have diverged from Biohub since it was last refreshed.

## Contents

```
.claude/skills/sae-feature-annotations/
├── SKILL.md                          # validity-first workflow, live→cache policy, 2-endpoint model
├── scripts/sae_features.py           # stdlib-only CLI: refresh / list / search / get
├── references/api.md                 # endpoints, base URL, auth, "decoder nearest neighbours" gloss
├── assets/feature_annotations.json   # offline table (ships unseeded; refresh populates it)
└── evals/evals.json                  # test prompts used to validate the skill
```

The CLI is dependency-free (stdlib `urllib`). Auth resolves from `--token` → `ESM_API_KEY` → `FORGE_TOKEN` (the same credential the Forge backend uses); base URL defaults to `https://biohub.ai` and is overridable.

## Notes for reviewers

- The cache **ships unseeded** — no fabricated or test data is committed. Running `sae_features.py refresh` with a live key from a network that can reach `biohub.ai` populates `assets/feature_annotations.json`.
- Auth is assumed to be `Authorization: Bearer <token>`, matching the Forge SDK convention. If the real annotation API differs, it's a one-line change isolated to `_http_get_json` in the script (flagged in `references/api.md`).
- The skill only *reads* annotations; producing the SAE features themselves is `boileroom`'s `SAE` model (on the `features/sae` branch).

## Testing

All CLI paths were exercised against a local mock of the Biohub API (live list/search/get, no-key cache fallback, refuse-detail-without-key, refresh-seeding). The skill was also run through three end-to-end scenarios — basic map lookup, extended per-feature detail, and a wrong-SAE guardrail — each producing correct, constraint-aware output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uWfyS4we8PKvNfUED6hCe

---
_Generated by [Claude Code](https://claude.ai/code/session_012uWfyS4we8PKvNfUED6hCe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools for looking up and searching ESMC-6B layer-60 SAE feature annotations.
  - Supports live Biohub data with offline fallback using a locally cached feature table.
  - Added feature-map refresh, listing, and detailed feature retrieval capabilities.
  - Provides clear handling for authentication, unavailable data, network errors, and incompatible SAE configurations.

- **Documentation**
  - Added usage guidance, API reference information, response interpretation details, and offline-mode limitations.

- **Tests**
  - Added coverage for basic lookups, detailed retrieval, and unsupported SAE configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->