### PR TITLE
fix/corrections_in_embeddings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},

--- a/src/bagel/energies.py
+++ b/src/bagel/energies.py
@@ -1469,8 +1469,8 @@ class EmbeddingsSimilarityEnergy(EnergyTerm):
         reference_embeddings = reference_embeddings / np.linalg.norm(reference_embeddings, axis=1, keepdims=True)
         self.reference_embeddings = reference_embeddings
         assert self.reference_embeddings.shape[0] == len(self.residue_groups[0][0]), (
-            f'Number of reference embeddings ({self.reference_embeddings.shape[0]}) does not'
-            f'match number of residues to include in energy term ({len(self.residue_groups[0])})'
+            f'Number of reference embeddings ({self.reference_embeddings.shape[0]}) does not '
+            f'match number of residues to include in energy term ({len(self.residue_groups[0][0])})'
         )
 
         assert isinstance(self.oracle, EmbeddingOracle), 'Oracle must be an instance of EmbeddingOracle'
@@ -1491,11 +1491,14 @@ class EmbeddingsSimilarityEnergy(EnergyTerm):
         # The following generate a 2D numpy array of shape (n_conserved_residues, n_features)
         # where n_conserved_residues is the number of residues in the reference embeddings
         # and n_features is the number of features in the embeddings.
-        # Note that n_conserved_residues must be equal to len(self.residue_groups[0])
+        # Note that n_conserved_residues must be equal to len(self.residue_groups[0][0])
         conserved_embeddings = embeddings[self.conserved_index_list(chains)]
 
         assert conserved_embeddings.shape == self.reference_embeddings.shape, (
-            f'Conserved embeddings shape {conserved_embeddings.shape} does not match reference embeddings {self.reference_embeddings.shape}'
+            f'Conserved embeddings shape {conserved_embeddings.shape} does not match reference '
+            f'embeddings shape {self.reference_embeddings.shape}. The reference embeddings are fixed '
+            f'at construction, so this term cannot follow residues added to or removed from its group '
+            f'at runtime (e.g. under GrandCanonical sampling); apply it to a fixed set of residues.'
         )
         # Normalise the conserved embeddings to unit length
         conserved_embeddings = conserved_embeddings / np.linalg.norm(conserved_embeddings, axis=1, keepdims=True)

--- a/tests/unit_tests/test_energies.py
+++ b/tests/unit_tests/test_energies.py
@@ -828,7 +828,9 @@ def test_embeddings_similarity_energy(
             residues=square_structure_residues,
             reference_embeddings=np.zeros((len(square_structure_residues), 1280)),  # Using typical ESM2 embedding size
         )
-        assert 'Oracle must be an instance of EmbeddingOracle' in str(e.value)
+    # Assert outside the `with` block: inside it the construction above raises first, so the
+    # message check would never execute.
+    assert 'Oracle must be an instance of EmbeddingOracle' in str(e.value)
 
     # Enforce correct number of reference embeddings
     with pytest.raises(AssertionError) as e:
@@ -839,10 +841,9 @@ def test_embeddings_similarity_energy(
                 (len(square_structure_residues) - 1, 1280)
             ),  # Using typical ESM2 embedding size
         )
-        assert (
-            'Number of reference embeddings (1) does not match number of residues to include in energy term (2)'
-            in str(e.value)
-        )
+    assert 'Number of reference embeddings (1) does not match number of residues to include in energy term (2)' in str(
+        e.value
+    )
 
     # Test dynamic reference embeddings
     # Create initial two-chain multimer state


### PR DESCRIPTION
## What

Fixes two message-only nits in `EmbeddingsSimilarityEnergy` (`src/bagel/energies.py`) plus a dead-code test that was meant to guard them. **No behavioural/logic change** — the residue-group handling itself was already correct.

## The nits

**1. Wrong count + missing space in the reference-count assert.** The failure message interpolated `len(self.residue_groups[0])`, but `residue_groups[0]` is a `(chain_ids, res_ids)` tuple, so that is *always* `2` regardless of how many residues are in the group. It also concatenated two f-string fragments without a space (`'... does not'` + `'match ...'` → `"does notmatch"`).

```diff
 assert self.reference_embeddings.shape[0] == len(self.residue_groups[0][0]), (
-    f'Number of reference embeddings ({self.reference_embeddings.shape[0]}) does not'
-    f'match number of residues to include in energy term ({len(self.residue_groups[0])})'
+    f'Number of reference embeddings ({self.reference_embeddings.shape[0]}) does not '
+    f'match number of residues to include in energy term ({len(self.residue_groups[0][0])})'
 )
```

The `assert` condition already used the correct `len(self.residue_groups[0][0])`; only the message was wrong. (The stale `# Note that n_conserved_residues must be equal to len(self.residue_groups[0])` comment in `compute()` is corrected to `[0][0]` for the same reason.)

**2. Cryptic shape-mismatch message in `compute()`.** The reference embeddings are fixed at construction, so if a residue in the term's group is added or removed at runtime (e.g. under `GrandCanonical` sampling) the conserved slice and the reference array desync and the assert fires with an opaque shape message. The message now names the cause and the remedy:

```diff
 assert conserved_embeddings.shape == self.reference_embeddings.shape, (
-    f'Conserved embeddings shape {conserved_embeddings.shape} does not match reference embeddings {self.reference_embeddings.shape}'
+    f'Conserved embeddings shape {conserved_embeddings.shape} does not match reference '
+    f'embeddings shape {self.reference_embeddings.shape}. The reference embeddings are fixed '
+    f'at construction, so this term cannot follow residues added to or removed from its group '
+    f'at runtime (e.g. under GrandCanonical sampling); apply it to a fixed set of residues.'
 )
```

## Why the bug in nit 1 went unnoticed — test fix

In `test_embeddings_similarity_energy`, the message assertions lived **inside** their `with pytest.raises(AssertionError):` blocks. The construction line raises first, so control leaves the block before the `assert` runs — the messages were never actually checked (which is exactly why the missing space survived). Moved both message assertions out of the `with` blocks so they now execute against the corrected messages.

## Testing

- `ruff check` and `ruff format --check` pass (repo-pinned ruff 0.15.13) on both files.
- The corrected message string was verified to match the test's expected string exactly.
- `test_embeddings_similarity_energy` requires a real ESM2 oracle backend (`--oracles modal`/`apptainer`), so it runs in CI rather than locally; the change is message/test-structure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uWfyS4we8PKvNfUED6hCe

---
_Generated by [Claude Code](https://claude.ai/code/session_012uWfyS4we8PKvNfUED6hCe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for embedding similarity calculations when residue selections change.
  * Error messages now provide clearer details when runtime embedding shapes do not match the configured reference.

* **Tests**
  * Updated validation tests to accurately check the resulting error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->