### PR TITLE
feat: add sae-feature-annotations skill

### DIFF
--- a/.claude/skills/sae-feature-annotations/SKILL.md
+++ b/.claude/skills/sae-feature-annotations/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: sae-feature-annotations
+description: >-
+  Look up what a Biohub ESM-C sparse-autoencoder (SAE) feature *means* — its label,
+  description, top-activating proteins, decoder neighbours, and activation statistics —
+  by querying the Biohub feature-annotation API. Use this whenever the user has SAE
+  feature indices (e.g. from `boileroom`'s `SAE` model / `pooled_features`) and wants to
+  interpret them: "what is SAE feature 12345", "which features fired on my protein and
+  what do they correspond to", "annotate these feature indices", "what proteins most
+  activate this feature", "find the zinc-binding SAE feature", "decoder nearest neighbours
+  of feature N", or any request to turn ESM-C SAE feature numbers into biology. Also
+  trigger when the user mentions Biohub feature annotations, the feature viewer, or the
+  ESMC-6B layer-60 SAE codebook. These annotations are only valid for the
+  `ESMC-6B-sae-layer60-k64-codebook16384` SAE — the skill says so up front and refuses to
+  pretend otherwise.
+---
+
+# Annotating ESM-C SAE features from Biohub
+
+This skill turns **SAE feature indices into biology**. A sparse autoencoder trained on
+ESM-C representations decomposes each residue into a sparse set of interpretable features
+(directions in a codebook). Biohub publishes an annotation for each feature — a human
+label, top-activating proteins, decoder neighbours, activation stats — and this skill
+fetches and presents them by querying the Biohub API live.
+
+## The one thing to say first, every time
+
+**These annotations are only valid for the SAE `ESMC-6B-sae-layer60-k64-codebook16384`**
+— ESM-C 6B, transformer layer 60, TopK k=64, codebook of 2**14 = 16384 features. This is
+the SAE from *Language Modeling Materializes a World Model of Protein Biology* (Biohub,
+2026), and the default Forge SAE that `boileroom`'s `SAE` model uses.
+
+A `feature_index` (0…16383) means something completely different under any other layer, k,
+or codebook. So before interpreting anything, **confirm the user produced their features
+with this exact SAE** (in `boileroom` that is the default `feature_source="forge"` path,
+i.e. `forge_sae_model = "esmc-6b-2024-12-sae-layer60-k64-codebook16384"`). If they used a
+local 300M/600M SAE or a different layer, tell them these labels do not apply and stop — do
+not hand them annotations that describe a different feature basis.
+
+Lead with this. Do not bury it under the results.
+
+## One source: the live Biohub API
+
+There is no bundled offline table. The two Biohub annotation endpoints are **public
+reads**, so the skill always queries them live. An API key is *optional*: if the user has
+one (`ESM_API_KEY` / `FORGE_TOKEN`, the same credential `boileroom`'s Forge backend uses)
+it is sent; if not, the request is made with an anonymous placeholder token, which is
+enough for the annotation endpoints. Base URL defaults to `https://biohub.ai`.
+
+If a deployment ever enforces auth and the anonymous call is rejected, the fix is to set
+`ESM_API_KEY`. That is the only case where a key matters for *reading annotations* —
+producing the features themselves is a different tool (see the last note).
+
+## Two endpoints = two levels of detail
+
+1. **The whole map, in one call** — `GET /esm/protein/api/v1alpha1/features` returns every
+   feature's `feature_index`, `label`, and short `description` at once (all 16384 in a
+   `{"data": [...]}` envelope). This is the `feature -> annotation` map, behind `list` and
+   `search`.
+
+2. **One feature, in full** — `GET /esm/protein/api/v1alpha1/features/{feature_index}`
+   returns the longform description, activation pattern, category, **top-activating
+   UniRef90 and SwissProt proteins**, **decoder nearest-neighbour feature indices**, and
+   **activation statistics**. This is behind `get`.
+
+See `references/api.md` for the exact request/response shapes, base URL, and auth details.
+
+## The tool
+
+Everything goes through one stdlib-only script (no dependencies to install):
+
+```
+scripts/sae_features.py
+  list   [--limit N]      # list features (map endpoint)
+  search <text>           # find features whose label/description matches <text>
+  get    <feature_index>  # full detail for one feature (detail endpoint)
+  # shared flags: --base-url, --token, --json
+```
+
+Auth resolves from `--token`, then `ESM_API_KEY`, then `FORGE_TOKEN`, else the anonymous
+placeholder. Base URL defaults to `https://biohub.ai` (`--base-url` / `BIOHUB_BASE_URL` to
+override).
+
+## Workflow
+
+1. **State the validity constraint** (the section above) and confirm the user's features
+   came from `ESMC-6B-sae-layer60-k64-codebook16384`. If not, stop and explain why the
+   labels don't apply.
+
+2. **Figure out what they need:**
+   - Just labels / short descriptions for some indices, or a keyword search →
+     `list` / `search`.
+   - Top-activating proteins, decoder neighbours, or activation stats for a feature →
+     `get`.
+
+3. **Query.** Run the relevant subcommand. It works with or without an API key; prefer the
+   user's own key via `ESM_API_KEY` (or `--token`) when they have one, but never ask them
+   to paste a secret into the chat if an env var will do, and never store it.
+
+4. **Present results plainly.** Give the label and description for each index; for `get`,
+   summarize the top proteins, decoder nearest-neighbour feature indices, and activation
+   statistics. Keep the feature index next to every annotation so the mapping is
+   unambiguous.
+
+## Notes
+
+- Don't invent labels. If the live call fails, report the error rather than guessing —
+  there is no offline substitute.
+- If Biohub rejects the request or the endpoint shape differs from `references/api.md`, the
+  auth/parse logic lives in one place (`_http_get_json` / `_live_feature_map` in the
+  script) — adjust there. The defaults (`Authorization: Bearer <token>`, base
+  `https://biohub.ai`, `{"data": [...]}` envelope) are verified against the live API.
+- This skill only *reads* annotations. Producing the SAE features themselves (running
+  ESM-C + the SAE to get `feature_index` values for a sequence) is `boileroom`'s `SAE`
+  model, on the `features/sae` branch — a different tool.

--- a/.claude/skills/sae-feature-annotations/evals/evals.json
+++ b/.claude/skills/sae-feature-annotations/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "sae-feature-annotations",
+  "evals": [
+    {
+      "id": 0,
+      "name": "basic-map-lookup",
+      "prompt": "I ran boileroom's SAE model on one of my proteins and pulled out the SAE feature indices that fired: 42, 100, and 777. What do these features correspond to biologically?",
+      "expected_output": "Leads with the ESMC-6B-sae-layer60-k64-codebook16384 validity note; returns the label+description for features 42/100/777 obtained by querying Biohub; keeps each index next to its annotation.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "extended-detail",
+      "prompt": "For SAE feature 42, I want the full picture - which real proteins activate it most (both UniRef90 and SwissProt), what its decoder nearest-neighbour features are, and its activation statistics.",
+      "expected_output": "Recognizes this needs the per-feature detail endpoint (`get`), queries it live (works anonymously; a key is optional), and summarizes top UniRef90+SwissProt proteins, decoder nearest-neighbour feature indices, and activation statistics for feature 42. Leads with the validity note.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "wrong-sae-guardrail",
+      "prompt": "I used a local ESM-C 600M sparse autoencoder at layer 27 (codebook 16384) and got feature index 88 firing strongly on my sequence. What does feature 88 correspond to? Look it up in the Biohub annotations.",
+      "expected_output": "Refuses to map feature 88 to a Biohub label because the Biohub annotations are only valid for ESMC-6B layer 60 (k64, codebook16384), not a 600M layer-27 SAE. Explains the feature basis differs; does not fabricate an annotation.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/sae-feature-annotations/references/api.md
+++ b/.claude/skills/sae-feature-annotations/references/api.md
@@ -1,0 +1,93 @@
+# Biohub SAE feature annotation API
+
+Reference for the two endpoints the skill uses. These annotations come from the
+sparse-autoencoder analysis in *Language Modeling Materializes a World Model of
+Protein Biology* (Biohub, 2026) and describe exactly one SAE:
+
+> **ESMC-6B-sae-layer60-k64-codebook16384** — ESM-C 6B, transformer layer 60,
+> TopK with k=64, codebook of 2**14 = 16384 features.
+
+A `feature_index` (0…16383) is only meaningful under this SAE. The same index
+under a different layer / k / codebook is an unrelated direction, so never reuse
+these labels for another SAE. This is the SAE the `boileroom` `SAE` model uses by
+default via its Forge backend (`forge_sae_model =
+esmc-6b-2024-12-sae-layer60-k64-codebook16384`, `forge_url = https://biohub.ai`).
+
+The shapes below were verified against the live API (`https://biohub.ai`).
+
+## Base URL and auth
+
+- **Base URL:** `https://biohub.ai` (same host as `boileroom`'s `forge_url`).
+  Override with `--base-url` or `BIOHUB_BASE_URL`.
+- **Auth:** the annotation endpoints are **public reads** — they return data for
+  an anonymous request. The script sends `Authorization: Bearer <token>`, using
+  `--token` / `ESM_API_KEY` / `FORGE_TOKEN` when set, otherwise an anonymous
+  placeholder. A real key is only needed if a deployment enforces auth and rejects
+  the anonymous call.
+- Auth is applied in one place — `_http_get_json` in `scripts/sae_features.py`. If
+  Biohub ever expects a different header name/scheme, change it there.
+
+## Endpoint 1 — the feature map (all features at once)
+
+```
+GET {base}/esm/protein/api/v1alpha1/features
+```
+
+Returns every SAE feature's `feature_index`, `label`, and short `description` in a
+single call (all 16384 features). This is the whole `feature -> annotation` map,
+behind `list` and `search`.
+
+The response is a `{"data": [...]}` envelope (the script is also liberal and
+accepts a bare list or `{"features": [...]}`). Each item:
+
+```json
+{ "feature_index": 0, "label": "Nudix N-terminal substrate-binding loop", "description": "short description" }
+```
+
+## Endpoint 2 — one feature's full detail
+
+```
+GET {base}/esm/protein/api/v1alpha1/features/{feature_index}
+```
+
+Returns a single flat JSON object (no envelope) with the extended record. Verified
+fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `feature_index` | int | The feature (0…16383). |
+| `label` | str | Short human label. |
+| `summary` | str | One-line summary. |
+| `description` | str | Longform description (a `Summary: … / Activation pattern: … / Exemplars: …` block). |
+| `activation_pattern` | str | Where along the sequence the feature fires. |
+| `category` | str | Coarse category, e.g. `Compositional bias`. |
+| `exemplar_protein_families` | str | Prose list of exemplar families. |
+| `uniref90_frequency` | int | How many UniRef90 proteins activate it. |
+| `uniref90_idf` | float | Inverse-document-frequency weight (rarer = higher). |
+| `uniref90_max_activation` | float | Peak activation seen across UniRef90. |
+| `top_100_uniref_ids` | list | Top-activating UniRef90 proteins: `[{"uniref_id": ..., "activation": ...}]`. |
+| `top_swissprot_activations` | list | Top-activating SwissProt proteins: `[{"uniprot_id": ..., "activation": ...}]`. |
+| `decoder_nearest_neighbors` | list[int] | Nearest-neighbour **feature indices** (see below). |
+| `threshold` | float | Activation threshold for the feature. |
+
+### How to read "decoder nearest neighbours"
+
+Each SAE feature owns a **decoder vector** — a direction in ESM-C's representation
+space that the feature writes back when it is active. The decoder nearest
+neighbours are the other features whose decoder vectors point most nearly the same
+way (cosine similarity in decoder space). The API returns them as a **plain list
+of neighbour feature indices** (e.g. `[8686, 12927, 3985, …]`), highest-similarity
+first; it does not return the similarity scores themselves. Look each neighbour up
+with `get` (or `list`) to see what it means.
+
+Because nearby directions tend to encode nearby biology, neighbours are usually
+semantically related features — helpful for interpreting a vaguely-labelled
+feature, and for spotting **feature splitting**, where one real concept is spread
+across several nearly-parallel features (a common SAE artifact).
+
+This is a property of the learned dictionary's geometry, **not** co-activation:
+two features can have near-parallel decoder directions yet rarely fire on the same
+residues. For "which proteins light this feature up," use `top_100_uniref_ids` /
+`top_swissprot_activations` and the activation statistics instead. Like everything
+here, neighbour relationships are specific to
+`ESMC-6B-sae-layer60-k64-codebook16384` and do not carry over to another SAE.

--- a/.claude/skills/sae-feature-annotations/scripts/sae_features.py
+++ b/.claude/skills/sae-feature-annotations/scripts/sae_features.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Part of the `sae-feature-annotations` Claude skill.
+# Queries Biohub for annotations of ESM-C sparse-autoencoder (SAE) features.
+# Standard library only (urllib) so it runs anywhere without installing anything.
+#
+# IMPORTANT: the annotations returned here are only meaningful for the SAE
+# ESMC-6B-sae-layer60-k64-codebook16384 (ESM-C 6B, layer 60, k=64, codebook
+# 16384). A feature_index means something completely different under any other
+# layer / k / codebook, so never mix these annotations with a different SAE.
+# -----------------------------------------------------------------------------
+"""Look up SAE feature annotations from Biohub.
+
+The Biohub feature-annotation endpoints are public reads, so this tool always
+queries them live — there is no bundled offline table. Two endpoints, two levels
+of detail:
+
+  * The **map** (feature_index -> label + short description) for *every* feature,
+    from ``GET {base}/esm/protein/api/v1alpha1/features``. Backs ``list`` /
+    ``search``.
+  * The **detail** for a single feature (longform description, activation pattern,
+    category, top-activating UniRef90 & SwissProt proteins, decoder
+    nearest-neighbour feature indices, activation statistics), from
+    ``GET {base}/esm/protein/api/v1alpha1/features/{index}``. Backs ``get``.
+
+Auth: if a real API key is available (``--token`` / ``ESM_API_KEY`` /
+``FORGE_TOKEN``) it is sent as ``Authorization: Bearer <token>``. If none is set,
+the request is still made with a placeholder token, since the annotation
+endpoints are public. If a deployment enforces auth and the anonymous call is
+rejected, set ``ESM_API_KEY`` (the same credential ``boileroom``'s Forge backend
+uses).
+
+Subcommands
+-----------
+  list                    List features (map endpoint).
+  search <text>           Search labels/descriptions for <text> (map endpoint).
+  get <feature_index>     Full detail for one feature (detail endpoint).
+
+Configuration (flags override environment override defaults)
+------------------------------------------------------------
+  --base-url   BIOHUB_BASE_URL      default https://biohub.ai
+  --token      ESM_API_KEY / FORGE_TOKEN
+
+Examples
+--------
+  python sae_features.py search "zinc"           # find features by keyword
+  python sae_features.py get 42 --json           # full detail for feature 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# The one SAE these annotations describe. Everything here is meaningless for any
+# other layer / k / codebook, so we lead with it in the banner.
+DEFAULT_SAE_MODEL = 'esmc-6b-2024-12-sae-layer60-k64-codebook16384'
+DEFAULT_BASE_URL = 'https://biohub.ai'
+API_PREFIX = '/esm/protein/api/v1alpha1'
+
+# The annotation endpoints are public; when the user has no key of their own we
+# still authenticate the request with this placeholder so the header is present.
+ANONYMOUS_TOKEN = 'anonymous'
+
+VALIDITY_BANNER = (
+    'These SAE feature annotations are only valid for '
+    'ESMC-6B-sae-layer60-k64-codebook16384 (ESM-C 6B, layer 60, k=64, '
+    'codebook 16384). They do not transfer to any other SAE.'
+)
+
+
+def _eprint(*args: object) -> None:
+    """Print to stderr so machine-readable stdout (``--json``) stays clean."""
+    print(*args, file=sys.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP
+# --------------------------------------------------------------------------- #
+def _resolve_token(explicit: str | None) -> tuple[str, bool]:
+    """Return ``(token_to_send, is_real)``.
+
+    Prefers an explicit ``--token``, then ``ESM_API_KEY``, then ``FORGE_TOKEN``.
+    If none is set, falls back to the anonymous placeholder so the public
+    endpoints can still be queried.
+    """
+    real = explicit or os.environ.get('ESM_API_KEY') or os.environ.get('FORGE_TOKEN')
+    if real:
+        return real, True
+    return ANONYMOUS_TOKEN, False
+
+
+def _http_get_json(url: str, token: str, timeout: int = 60) -> object:
+    """GET a URL and parse JSON. Raises on HTTP/network/JSON errors.
+
+    Auth is a bearer token (the same credential ``ESMCForgeInferenceClient`` uses,
+    or the anonymous placeholder). If Biohub ever expects a different header,
+    adjust it here — it is the single place auth is applied.
+    """
+    request = urllib.request.Request(url, headers={'Accept': 'application/json'})
+    request.add_header('Authorization', f'Bearer {token}')
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 (trusted host)
+        return json.loads(response.read().decode('utf-8'))
+
+
+def _features_url(base_url: str) -> str:
+    return f'{base_url.rstrip("/")}{API_PREFIX}/features'
+
+
+def _feature_detail_url(base_url: str, feature_index: int) -> str:
+    return f'{base_url.rstrip("/")}{API_PREFIX}/features/{feature_index}'
+
+
+def _note_auth(is_real: bool) -> None:
+    if not is_real:
+        _eprint(
+            '[info] no API key set (ESM_API_KEY / FORGE_TOKEN / --token); querying '
+            'Biohub anonymously. Set a key for authenticated access if required.'
+        )
+
+
+def _live_feature_map(base_url: str, token: str) -> list[dict]:
+    """Fetch the full feature map, normalized to a list of dicts with at least
+    ``feature_index``, ``label``, ``description``."""
+    payload = _http_get_json(_features_url(base_url), token)
+    # Be liberal about the envelope: accept a bare list, {"data": [...]},
+    # or {"features": [...]}. Biohub currently returns {"data": [...]}.
+    if isinstance(payload, dict):
+        payload = payload.get('data', payload.get('features', []))
+    if not isinstance(payload, list):
+        raise ValueError(f'Unexpected features payload shape: {type(payload).__name__}')
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands
+# --------------------------------------------------------------------------- #
+def _match(feature: dict, text: str) -> bool:
+    hay = f'{feature.get("label", "")} {feature.get("description", "")}'.lower()
+    return text.lower() in hay
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    token, is_real = _resolve_token(args.token)
+    _note_auth(is_real)
+    try:
+        features = _live_feature_map(args.base_url, token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError) as exc:
+        _eprint(f'[error] could not fetch feature map from Biohub: {exc}')
+        return 1
+    if getattr(args, 'query', None):
+        features = [f for f in features if _match(f, args.query)]
+    features = sorted(features, key=lambda f: f.get('feature_index', 0))
+    if args.limit:
+        features = features[: args.limit]
+    if args.json:
+        print(json.dumps({'count': len(features), 'features': features}, indent=2))
+    else:
+        _eprint(VALIDITY_BANNER)
+        _eprint(f'{len(features)} feature(s):')
+        for f in features:
+            print(f'  {f.get("feature_index"):>6}  {f.get("label", "")}')
+            if f.get('description'):
+                print(f'          {f["description"]}')
+    return 0
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    token, is_real = _resolve_token(args.token)
+    _note_auth(is_real)
+    url = _feature_detail_url(args.base_url, args.feature_index)
+    _eprint(f'[info] GET {url}')
+    try:
+        detail = _http_get_json(url, token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError) as exc:
+        _eprint(f'[error] could not fetch feature {args.feature_index}: {exc}')
+        return 1
+    if not args.json:
+        _eprint(VALIDITY_BANNER)
+    print(json.dumps(detail, indent=2))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    def add_common(sub: argparse.ArgumentParser) -> None:
+        sub.add_argument('--base-url', default=os.environ.get('BIOHUB_BASE_URL', DEFAULT_BASE_URL))
+        sub.add_argument('--token', default=None, help='API key; else ESM_API_KEY / FORGE_TOKEN, else anonymous.')
+
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    p_list = subparsers.add_parser('list', help='List features from the Biohub map endpoint.')
+    add_common(p_list)
+    p_list.add_argument('--limit', type=int, default=0, help='Max rows (0 = all).')
+    p_list.add_argument('--json', action='store_true')
+    p_list.set_defaults(func=cmd_list, query=None)
+
+    p_search = subparsers.add_parser('search', help='Search labels/descriptions on the map endpoint.')
+    add_common(p_search)
+    p_search.add_argument('query', help='Text to match in label or description.')
+    p_search.add_argument('--limit', type=int, default=0)
+    p_search.add_argument('--json', action='store_true')
+    p_search.set_defaults(func=cmd_list)
+
+    p_get = subparsers.add_parser('get', help='Full detail for one feature from the detail endpoint.')
+    add_common(p_get)
+    p_get.add_argument('feature_index', type=int)
+    p_get.add_argument('--json', action='store_true')
+    p_get.set_defaults(func=cmd_get)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biobagel"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   {name = "Jakub Lála", email = "jakublala@gmail.com"},
   {name = "Ayham Al-Saffar", email = "ayham.saffar@gmail.com"},


### PR DESCRIPTION
## What

Adds a Claude skill, **`sae-feature-annotations`**, that turns ESM-C sparse-autoencoder (SAE) feature indices into biology by querying the Biohub feature-annotation API.

The annotations describe exactly one SAE — **`ESMC-6B-sae-layer60-k64-codebook16384`** (ESM-C 6B, layer 60, k=64, codebook 16384), the default Forge SAE used by `boileroom`'s `SAE` model. The skill leads with this validity constraint on every use and refuses to map indices that came from a different SAE.

This **supersedes #139**: same skill, but the design is now verified against the live Biohub API and the offline-cache approach has been dropped in favour of always querying live.

## How it works

The two Biohub annotation endpoints are **public reads**, so the skill always queries them live — there is no bundled offline table:

- `GET /esm/protein/api/v1alpha1/features` → the full `feature_index → label + description` map (all 16384 features, `{"data": [...]}` envelope). Backs `list` / `search`.
- `GET /esm/protein/api/v1alpha1/features/{index}` → per-feature detail: longform description, activation pattern, category, top-activating UniRef90 & SwissProt proteins, decoder nearest-neighbour feature indices, and activation statistics. Backs `get`.

Auth is optional: a real key (`--token` → `ESM_API_KEY` → `FORGE_TOKEN`, the same credential the Forge backend uses) is sent when set; otherwise the request goes with an anonymous placeholder token, which the annotation endpoints accept. If a deployment enforces auth, setting `ESM_API_KEY` is the fix.

## Contents

```
.claude/skills/sae-feature-annotations/
├── SKILL.md                      # validity-first workflow, always-live 2-endpoint model
├── scripts/sae_features.py       # stdlib-only CLI: list / search / get
├── references/api.md             # endpoints, base URL, auth, verified response shapes
└── evals/evals.json              # test prompts used to validate the skill
```

The CLI is dependency-free (stdlib `urllib`).

## Verified against the live API

All endpoint shapes were confirmed against `https://biohub.ai`, not assumed:

- Map: `{"data": [...]}`, 16384 features (indices 0–16383, matching the codebook).
- Detail fields: `label`, `summary`, `description`, `activation_pattern`, `category`, `exemplar_protein_families`, `uniref90_frequency`, `uniref90_idf`, `uniref90_max_activation`, `top_100_uniref_ids`, `top_swissprot_activations`, `decoder_nearest_neighbors`, `threshold`.
- `decoder_nearest_neighbors` is a **plain list of neighbour feature indices** (no similarity scores) — `references/api.md` documents this correctly.

## Testing

Exercised end-to-end against the live API — `list`, `search "zinc"`, and `get 42` — both anonymously and with a key. `ruff check` and `ruff format --check` pass on the script.

## Notes for reviewers

- The skill only *reads* annotations. Producing the SAE features themselves is `boileroom`'s `SAE` model (on the `features/sae` branch).
- The "anonymous read" behaviour was observed through a proxied environment; the code still prefers a real key when one is present and documents `ESM_API_KEY` as the fallback if a deployment rejects anonymous calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)